### PR TITLE
Add initial support for re-initializing media elements upon selective refresh

### DIFF
--- a/core-media-widgets.php
+++ b/core-media-widgets.php
@@ -31,6 +31,8 @@
  */
 function wp32417_default_scripts( WP_Scripts $scripts ) {
 	$scripts->add( 'wp-media-widget', plugin_dir_url( __FILE__ ) . 'wp-admin/js/widgets/media-widget.js', array( 'jquery', 'media-models', 'media-views', 'wp-mediaelement' ) );
+
+	$scripts->add_inline_script( 'customize-selective-refresh', file_get_contents( dirname( __FILE__ ) . '/wp-includes/js/customize-selective-refresh-extras.js' ) );
 }
 add_action( 'wp_default_scripts', 'wp32417_default_scripts' );
 

--- a/wp-includes/js/customize-selective-refresh-extras.js
+++ b/wp-includes/js/customize-selective-refresh-extras.js
@@ -1,0 +1,16 @@
+/* global wp */
+(function( api ) {
+	'use strict';
+
+	/*
+	 * The following logic should be placed at https://github.com/WordPress/wordpress-develop/blob/4.7.2/src/wp-includes/js/customize-selective-refresh.js#L471
+	 */
+	api.selectiveRefresh.bind( 'partial-content-rendered', function initializeMediaElements() {
+
+		// @todo If audio, first ensure that wp_audio_shortcode_library filters away mediaelement; if video, check wp_video_shortcode_library filters the same.
+		if ( wp.mediaelement ) {
+			wp.mediaelement.initialize();
+		}
+	} );
+
+})( wp.customize );


### PR DESCRIPTION
This fixes an issue with the video and audio widgets where a change to the widget in the customizer causes the widgets to selectively refresh and then fail to re-initialize ME.js.