### PR TITLE
Prefix media widgets

### DIFF
--- a/wp-includes/widgets/class-wp-widget-audio.php
+++ b/wp-includes/widgets/class-wp-widget-audio.php
@@ -23,9 +23,10 @@ class WP_Widget_Audio extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'audio', __( 'Audio' ), array(
-			'classname'   => 'widget_audio',
+		parent::__construct( 'wp-audio', __( 'Audio' ), array(
+			'classname'   => 'widget_wp-audio',
 			'description' => __( 'Displays an audio file.' ),
+			'mime_type'   => 'audio',
 		) );
 
 		if ( $this->is_preview() ) {

--- a/wp-includes/widgets/class-wp-widget-audio.php
+++ b/wp-includes/widgets/class-wp-widget-audio.php
@@ -23,8 +23,8 @@ class WP_Widget_Audio extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'wp-audio', __( 'Audio' ), array(
-			'classname'   => 'widget_wp-audio',
+		parent::__construct( 'media-audio', __( 'Audio' ), array(
+			'classname'   => 'widget_media-audio',
 			'description' => __( 'Displays an audio file.' ),
 			'mime_type'   => 'audio',
 		) );

--- a/wp-includes/widgets/class-wp-widget-audio.php
+++ b/wp-includes/widgets/class-wp-widget-audio.php
@@ -23,8 +23,7 @@ class WP_Widget_Audio extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'media-audio', __( 'Audio' ), array(
-			'classname'   => 'widget_media-audio',
+		parent::__construct( 'media_audio', __( 'Audio' ), array(
 			'description' => __( 'Displays an audio file.' ),
 			'mime_type'   => 'audio',
 		) );

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -23,8 +23,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'media-image', __( 'Image' ), array(
-			'classname'   => 'widget_media-image',
+		parent::__construct( 'media_image', __( 'Image' ), array(
 			'description' => __( 'Displays an image file.' ),
 			'mime_type'   => 'image',
 		) );

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -23,8 +23,8 @@ class WP_Widget_Image extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'wp-image', __( 'Image' ), array(
-			'classname'   => 'widget_wp-image',
+		parent::__construct( 'media-image', __( 'Image' ), array(
+			'classname'   => 'widget_media-image',
 			'description' => __( 'Displays an image file.' ),
 			'mime_type'   => 'image',
 		) );

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -23,9 +23,10 @@ class WP_Widget_Image extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'image', __( 'Image' ), array(
-			'classname'   => 'widget_image',
+		parent::__construct( 'wp-image', __( 'Image' ), array(
+			'classname'   => 'widget_wp-image',
 			'description' => __( 'Displays an image file.' ),
+			'mime_type'   => 'image',
 		) );
 	}
 

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -193,7 +193,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 					type="button"
 					class="button select-media widefat"
 					data-id="<?php echo esc_attr( $widget_id ); ?>"
-					data-type="<?php echo esc_attr( $this->id_base ); ?>"
+					data-type="<?php echo esc_attr( $this->widget_options['mime_type'] ); ?>"
 				>
 					<?php $attachment ? esc_html_e( 'Change Media' ) : esc_html_e( 'Select Media' ); ?>
 				</button>

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -43,7 +43,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 */
 	public function __construct( $id_base, $name, $widget_options = array(), $control_options = array() ) {
 		$widget_opts = wp_parse_args( $widget_options, array(
-			'classname' => 'widget_media',
 			'description' => __( 'An image, video, or audio file.' ),
 			'customize_selective_refresh' => true,
 		) );

--- a/wp-includes/widgets/class-wp-widget-video.php
+++ b/wp-includes/widgets/class-wp-widget-video.php
@@ -23,8 +23,8 @@ class WP_Widget_Video extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'wp-video', __( 'Video' ), array(
-			'classname'   => 'widget_wp-video',
+		parent::__construct( 'media-video', __( 'Video' ), array(
+			'classname'   => 'widget_media-video',
 			'description' => __( 'Displays a video file.' ),
 			'mime_type'   => 'video',
 		) );

--- a/wp-includes/widgets/class-wp-widget-video.php
+++ b/wp-includes/widgets/class-wp-widget-video.php
@@ -23,9 +23,10 @@ class WP_Widget_Video extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'video', __( 'Video' ), array(
-			'classname'   => 'widget_video',
+		parent::__construct( 'wp-video', __( 'Video' ), array(
+			'classname'   => 'widget_wp-video',
 			'description' => __( 'Displays a video file.' ),
+			'mime_type'   => 'video',
 		) );
 
 		if ( $this->is_preview() ) {

--- a/wp-includes/widgets/class-wp-widget-video.php
+++ b/wp-includes/widgets/class-wp-widget-video.php
@@ -23,8 +23,7 @@ class WP_Widget_Video extends WP_Widget_Media {
 	 * @access public
 	 */
 	public function __construct() {
-		parent::__construct( 'media-video', __( 'Video' ), array(
-			'classname'   => 'widget_media-video',
+		parent::__construct( 'media_video', __( 'Video' ), array(
 			'description' => __( 'Displays a video file.' ),
 			'mime_type'   => 'video',
 		) );


### PR DESCRIPTION
Prefixes the widgets `id_base` to not clash with existing audio/image/video widgets. Also adds a proper widget option to pass on the widgets mime type.

See https://wordpress.slack.com/archives/core-customize/p1489080794278492