### PR TITLE
Introduce instance schema to declaratively sanitize instance props

### DIFF
--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -40,7 +40,7 @@
 
 			props = {
 				attachment_id: attachment.id,
-				url: attachment.url,
+				url: attachment.sizes[ displaySettings.size ].url,
 				size: displaySettings.size,
 				width: 0, // Reset.
 				height: 0, // Reset.

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -48,7 +48,7 @@
 				caption: attachment.caption,
 				alt: attachment.alt,
 				link_type: displaySettings.link,
-				link_url: displaySettings.link_url
+				link_url: displaySettings.linkUrl
 			};
 
 			return props;

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -4,7 +4,6 @@
 
 	var ImageWidgetModel, ImageWidgetControl;
 
-	// @todo Implement validate methods to force the right type.
 	// Defaults will get set via WP_Widget_Image::enqueue_admin_scripts().
 	ImageWidgetModel = component.MediaWidgetModel.extend( {} );
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -68,7 +68,11 @@ wp.mediaWidgets = ( function( $ ) {
 				} );
 			}
 
-			// Sync the widget instance model attributes onto the hidden inputs that widgets currently use to store the state.
+			/*
+			 * Sync the widget instance model attributes onto the hidden inputs that widgets currently use to store the state.
+			 * In the future, when widgets are JS-driven, the underlying widget instance data should be exposed as a model
+			 * from the start, without having to sync with hidden fields. See <https://core.trac.wordpress.org/ticket/33507>.
+			 */
 			control.listenTo( control.model, 'change', function() {
 				control.$el.next( '.widget-content' ).find( '.media-widget-instance-property' ).each( function() {
 					var input = $( this ), value;
@@ -232,6 +236,11 @@ wp.mediaWidgets = ( function( $ ) {
 
 		ModelConstructor = component.modelConstructors[ idBase ] || component.MediaWidgetModel;
 
+		/*
+		 * Sync the widget instance model attributes onto the hidden inputs that widgets currently use to store the state.
+		 * In the future, when widgets are JS-driven, the underlying widget instance data should be exposed as a model
+		 * from the start, without having to sync with hidden fields. See <https://core.trac.wordpress.org/ticket/33507>.
+		 */
 		// @todo Warning: One of the fields must have the 'title' name, and the value must be a bare string for the sake of populating the widget title.
 		widgetId = widgetForm.find( '> .widget-id' ).val();
 		controlContainer = $( '<div class="media-widget-control"></div>' );

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -163,8 +163,7 @@ wp.mediaWidgets = ( function( $ ) {
 		isSelected: function isSelected() {
 			var control = this;
 
-			// @todo attachment_id should always be an integer, but it can be "0" here.
-			return Boolean( Number( control.model.get( 'attachment_id' ) ) || control.model.get( 'url' ) );
+			return Boolean( control.model.get( 'attachment_id' ) || control.model.get( 'url' ) );
 		},
 
 		/**

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -28,16 +28,9 @@ class WP_Widget_Image extends WP_Widget_Media {
 		return array_merge(
 			parent::get_instance_schema(),
 			array(
-				'attachment_id' => array(
-					'type' => 'integer',
-					'default' => 0,
-				),
-				'url' => array(
-					'type' => 'string',
-					'default' => '',
-				),
 				'size' => array(
-					'type' => 'string', // @todo enum.
+					'type' => 'string',
+					'enum' => array_merge( get_intermediate_image_sizes(), array( 'full', 'custom' ) ),
 					'default' => 'full',
 				),
 				'width' => array( // Via 'customWidth', only when size=custom; otherwise via 'width'.
@@ -52,36 +45,44 @@ class WP_Widget_Image extends WP_Widget_Media {
 				),
 
 				'align' => array(
-					'type' => 'string', // @todo enum.
-					'default' => '',
+					'type' => 'string',
+					'enum' => array( 'none', 'left', 'right', 'center' ),
+					'default' => 'none',
 				),
 				'caption' => array(
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'alt' => array(
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'link_type' => array( // Via 'link' property.
-					'type' => 'string', // @todo enum.
+					'type' => 'string',
+					'enum' => array( 'none', 'file', 'post', 'custom' ),
 					'default' => 'none',
 				),
 				'link_url' => array( // Via 'linkUrl' property.
 					'type' => 'string',
 					'default' => '',
+					'format' => 'uri',
 				),
 				'image_classes' => array( // Via 'extraClasses' property.
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'link_classes' => array( // Via 'linkClassName' property.
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'link_rel' => array( // Via 'linkRel' property.
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 				'link_target_blank' => array( // Via 'linkTargetBlank' property.
 					'type' => 'boolean',
@@ -90,6 +91,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 				'image_title' => array( // Via 'title' property.
 					'type' => 'string',
 					'default' => '',
+					'sanitize_callback' => 'sanitize_text_field',
 				),
 
 				/*
@@ -123,51 +125,6 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
 		) );
-	}
-
-	/**
-	 * Sanitizes the widget form values as they are saved.
-	 *
-	 * @since 4.8.0
-	 * @access public
-	 *
-	 * @see WP_Widget::update()
-	 *
-	 * @param array $new_instance Values just sent to be saved.
-	 * @param array $instance Previously saved values from database.
-	 * @return array Updated safe values to be saved.
-	 */
-	public function update( $new_instance, $instance ) {
-		$instance = parent::update( $new_instance, $instance );
-
-		if ( in_array( $new_instance['align'], array( 'none', 'left', 'right', 'center' ), true ) ) {
-			$instance['align'] = $new_instance['align'];
-		}
-
-		$image_sizes = array_merge( get_intermediate_image_sizes(), array( 'full', 'custom' ) );
-		if ( in_array( $new_instance['size'], $image_sizes, true ) ) {
-			$instance['size'] = $new_instance['size'];
-		}
-
-		$instance['width'] = intval( $new_instance['width'] );
-		$instance['height'] = intval( $new_instance['height'] );
-
-		if ( in_array( $new_instance['link_type'], array( 'none', 'file', 'post', 'custom' ), true ) ) {
-			$instance['link_type'] = $new_instance['link_type'];
-		}
-
-		$instance['link_url'] = esc_url_raw( $new_instance['link_url'] );
-
-		$instance['caption'] = sanitize_text_field( $new_instance['caption'] );
-		$instance['alt'] = sanitize_text_field( $new_instance['alt'] );
-
-		$instance['image_classes'] = sanitize_text_field( $new_instance['image_classes'] );
-		$instance['link_classes'] = sanitize_text_field( $new_instance['link_classes'] );
-		$instance['link_rel'] = sanitize_text_field( $new_instance['link_rel'] );
-		$instance['image_title'] = sanitize_text_field( $new_instance['image_title'] );
-		$instance['link_target_blank'] = (bool) $new_instance['link_target_blank'];
-
-		return $instance;
 	}
 
 	/**

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -17,6 +17,26 @@
 class WP_Widget_Image extends WP_Widget_Media {
 
 	/**
+	 * Constructor.
+	 *
+	 * @since  4.8.0
+	 * @access public
+	 */
+	public function __construct() {
+		parent::__construct( 'media_image', __( 'Image' ), array(
+			'description' => __( 'Displays an image file.' ),
+			'mime_type'   => 'image',
+		) );
+
+		$this->l10n = array_merge( $this->l10n, array(
+			'no_media_selected' => __( 'No image selected' ),
+			'edit_media' => __( 'Edit Image' ),
+			'change_media' => __( 'Change Image' ),
+			'select_media' => __( 'Select Image' ),
+		) );
+	}
+
+	/**
 	 * Get instance schema.
 	 *
 	 * This is protected because it may become part of WP_Widget eventually.
@@ -105,26 +125,6 @@ class WP_Widget_Image extends WP_Widget_Media {
 				 */
 			)
 		);
-	}
-
-	/**
-	 * Constructor.
-	 *
-	 * @since  4.8.0
-	 * @access public
-	 */
-	public function __construct() {
-		parent::__construct( 'media_image', __( 'Image' ), array(
-			'description' => __( 'Displays an image file.' ),
-			'mime_type'   => 'image',
-		) );
-
-		$this->l10n = array_merge( $this->l10n, array(
-			'no_media_selected' => __( 'No image selected' ),
-			'edit_media' => __( 'Edit Image' ),
-			'change_media' => __( 'Change Image' ),
-			'select_media' => __( 'Select Image' ),
-		) );
 	}
 
 	/**

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -17,6 +17,95 @@
 class WP_Widget_Image extends WP_Widget_Media {
 
 	/**
+	 * Get instance schema.
+	 *
+	 * This is protected because it may become part of WP_Widget eventually.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/35574
+	 * @return array
+	 */
+	protected function get_instance_schema() {
+		return array_merge(
+			parent::get_instance_schema(),
+			array(
+				'attachment_id' => array(
+					'type' => 'integer',
+					'default' => 0,
+				),
+				'url' => array(
+					'type' => 'string',
+					'default' => '',
+				),
+				'size' => array(
+					'type' => 'string', // @todo enum.
+					'default' => 'full',
+				),
+				'width' => array( // Via 'customWidth', only when size=custom; otherwise via 'width'.
+					'type' => 'integer',
+					'minimum' => 0,
+					'default' => 0,
+				),
+				'height' => array( // Via 'customHeight', only when size=custom; otherwise via 'height'.
+					'type' => 'integer',
+					'minimum' => 0,
+					'default' => 0,
+				),
+
+				'align' => array(
+					'type' => 'string', // @todo enum.
+					'default' => '',
+				),
+				'caption' => array(
+					'type' => 'string',
+					'default' => '',
+				),
+				'alt' => array(
+					'type' => 'string',
+					'default' => '',
+				),
+				'link_type' => array( // Via 'link' property.
+					'type' => 'string', // @todo enum.
+					'default' => 'none',
+				),
+				'link_url' => array( // Via 'linkUrl' property.
+					'type' => 'string',
+					'default' => '',
+				),
+				'image_classes' => array( // Via 'extraClasses' property.
+					'type' => 'string',
+					'default' => '',
+				),
+				'link_classes' => array( // Via 'linkClassName' property.
+					'type' => 'string',
+					'default' => '',
+				),
+				'link_rel' => array( // Via 'linkRel' property.
+					'type' => 'string',
+					'default' => '',
+				),
+				'link_target_blank' => array( // Via 'linkTargetBlank' property.
+					'type' => 'boolean',
+					'default' => false,
+				),
+				'image_title' => array( // Via 'title' property.
+					'type' => 'string',
+					'default' => '',
+				),
+
+				/*
+				 * There are two additional properties exposed by the PostImage modal
+				 * that don't seem to be relevant, as they may only be derived read-only
+				 * values:
+				 * - originalUrl
+				 * - aspectRatio
+				 * - height (redundant when size is not custom)
+				 * - width (redundant when size is not custom)
+				 */
+			)
+		);
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @since  4.8.0
@@ -34,42 +123,6 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
 		) );
-
-		// @todo The following should be broken out into a schema that has the requisite types and sanitize_callbacks defined.
-		$this->default_instance = array_merge(
-			$this->default_instance,
-			array(
-				'attachment_id' => 0,
-				'url' => '', // This should only be set in the instance if attachment_id is empty.
-
-				'size' => 'full',
-				'width' => 0, // Via 'customWidth', only when size=custom; otherwise via 'width'.
-				'height' => 0, // Via 'customHeight', only when size=custom; otherwise via 'height'.
-
-				'align' => '',
-				'caption' => '',
-				'alt' => '',
-
-				'link_type' => 'none', // Via 'link' property.
-				'link_url' => '', // Via 'linkUrl' property.
-
-				'image_classes' => '', // Via 'extraClasses' property.
-				'link_classes' => '', // Via 'linkClassName' property.
-				'link_rel' => '', // Via 'linkRel' property.
-				'link_target_blank' => false, // Via 'linkTargetBlank' property.
-				'image_title' => '', // Via 'title' property.
-
-				/*
-				 * There are two additional properties exposed by the PostImage modal
-				 * that don't seem to be relevant, as they may only be derived read-only
-				 * values:
-				 * - originalUrl
-				 * - aspectRatio
-				 * - height (redundant when size is not custom)
-				 * - width (redundant when size is not custom)
-				 */
-			)
-		);
 	}
 
 	/**
@@ -127,7 +180,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 	 * @return void
 	 */
 	public function render_media( $instance ) {
-		$instance = array_merge( $this->default_instance, $instance );
+		$instance = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
 		$instance = wp_parse_args( $instance, array(
 			'size' => 'thumbnail',
 		) );
@@ -219,7 +272,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 			sprintf(
 				'wp.mediaWidgets.modelConstructors[ %s ].prototype.defaults = %s;',
 				wp_json_encode( $this->id_base ),
-				wp_json_encode( $this->default_instance )
+				wp_json_encode( wp_list_pluck( $this->get_instance_schema(), 'default' ) )
 			)
 		);
 

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -170,7 +170,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 		}
 
 		$size = $instance['size'];
-		if ( 'custom' === $size || ! has_image_size( $size ) ) {
+		if ( 'custom' === $size || ! in_array( $size, array_merge( get_intermediate_image_sizes(), array( 'full' ) ) ) ) {
 			$size = array( $instance['width'], $instance['height'] );
 		}
 

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -224,12 +224,16 @@ class WP_Widget_Image extends WP_Widget_Media {
 		$handle = 'media-image-widget';
 		wp_enqueue_script( $handle );
 
+		$exported_schema = array();
+		foreach ( $this->get_instance_schema() as $field => $field_schema ) {
+			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format' ) );
+		}
 		wp_add_inline_script(
 			$handle,
 			sprintf(
-				'wp.mediaWidgets.modelConstructors[ %s ].prototype.defaults = %s;',
+				'wp.mediaWidgets.modelConstructors[ %s ].prototype.schema = %s;',
 				wp_json_encode( $this->id_base ),
-				wp_json_encode( wp_list_pluck( $this->get_instance_schema(), 'default' ) )
+				wp_json_encode( $exported_schema )
 			)
 		);
 

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -17,16 +17,29 @@
 abstract class WP_Widget_Media extends WP_Widget {
 
 	/**
-	 * Default instance.
+	 * Get instance schema.
 	 *
-	 * @todo The fields in this should be expanded out into full schema entries, with types and sanitize_callbacks.
-	 * @var array
+	 * This is protected because it may become part of WP_Widget eventually.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/35574
+	 * @return array
 	 */
-	protected $default_instance = array(
-		'attachment_id' => 0,
-		'url' => '',
-		'title' => '',
-	);
+	protected function get_instance_schema() {
+		return array(
+			'attachment_id' => array(
+				'type' => 'integer',
+				'default' => 0,
+			),
+			'url' => array(
+				'type' => 'string',
+				'default' => '',
+			),
+			'title' => array(
+				'type' => 'string',
+				'default' => '',
+			),
+		);
+	}
 
 	/**
 	 * Translation labels.
@@ -97,7 +110,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @param array $instance Saved setting from the database.
 	 */
 	public function widget( $args, $instance ) {
-		$instance = wp_parse_args( $instance, $this->default_instance );
+		$instance = wp_parse_args( $instance, wp_list_pluck( $this->get_instance_schema(), 'default' ) );
 
 		echo $args['before_widget'];
 
@@ -177,9 +190,10 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @return void
 	 */
 	public function form( $instance ) {
+		$instance_schema = $this->get_instance_schema();
 		$instance = wp_array_slice_assoc(
-			wp_parse_args( (array) $instance, $this->default_instance ),
-			array_keys( $this->default_instance )
+			wp_parse_args( (array) $instance, wp_list_pluck( $instance_schema, 'default' ) ),
+			array_keys( wp_list_pluck( $instance_schema, 'default' ) )
 		);
 		?>
 		<?php foreach ( $instance as $name => $value ) : ?>

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -17,34 +17,6 @@
 abstract class WP_Widget_Media extends WP_Widget {
 
 	/**
-	 * Get instance schema.
-	 *
-	 * This is protected because it may become part of WP_Widget eventually.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/35574
-	 * @return array
-	 */
-	protected function get_instance_schema() {
-		return array(
-			'attachment_id' => array(
-				'type' => 'integer',
-				'default' => 0,
-				'minimum' => 0,
-			),
-			'url' => array(
-				'type' => 'string',
-				'default' => '',
-				'format' => 'uri',
-			),
-			'title' => array(
-				'type' => 'string',
-				'default' => '',
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		);
-	}
-
-	/**
 	 * Translation labels.
 	 *
 	 * @since 4.8.0
@@ -99,6 +71,34 @@ abstract class WP_Widget_Media extends WP_Widget {
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_admin_scripts' ) );
 		add_action( 'admin_footer-widgets.php', array( $this, 'maybe_print_control_templates' ) );
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'maybe_print_control_templates' ) );
+	}
+
+	/**
+	 * Get instance schema.
+	 *
+	 * This is protected because it may become part of WP_Widget eventually.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/35574
+	 * @return array
+	 */
+	protected function get_instance_schema() {
+		return array(
+			'attachment_id' => array(
+				'type' => 'integer',
+				'default' => 0,
+				'minimum' => 0,
+			),
+			'url' => array(
+				'type' => 'string',
+				'default' => '',
+				'format' => 'uri',
+			),
+			'title' => array(
+				'type' => 'string',
+				'default' => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
 	}
 
 	/**

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -137,6 +137,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @access public
 	 *
 	 * @see WP_Widget::update()
+	 * @see WP_REST_Request::has_valid_params()
+	 * @see WP_REST_Request::sanitize_params()
 	 *
 	 * @param array $new_instance Values just sent to be saved.
 	 * @param array $instance     Previously saved values from database.


### PR DESCRIPTION
Re-use REST API infrastructure for validating and sanitizing instance properties. This allows us to eliminate having to override the `update` method for media widget subclasses.

This draws inspiration from:
* [#35574](https://core.trac.wordpress.org/ticket/35574): Add REST API JSON schema information to WP_Widget
* [JS Widgets](https://github.com/xwp/wp-js-widgets): [`WP_JS_Widget::get_item_schema()`](https://github.com/xwp/wp-js-widgets/blob/0.4.1/php/class-wp-js-widget.php), though the JS Widgets plugin also has widget endpoints which can then be [used](https://github.com/xwp/wp-js-widgets/blob/0.4.1/php/class-js-widgets-plugin.php#L632-L650) to create `PUT` requests for letting `WP_REST_Request::has_valid_params()` and `WP_REST_Request::sanitize_params()` do the validation and sanitization for us. In the media widget there is no endpoint (yet) so we have to iterate over the schema ourselves to validate and sanitize the instance props.