### PR TITLE
Fix widget initialization on admin screen

### DIFF
--- a/core-media-widgets.php
+++ b/core-media-widgets.php
@@ -31,6 +31,7 @@
  */
 function wp32417_default_scripts( WP_Scripts $scripts ) {
 	$scripts->add( 'media-widgets', plugin_dir_url( __FILE__ ) . 'wp-admin/js/widgets/media-widgets.js', array( 'jquery', 'media-models', 'media-views' ) );
+	$scripts->add_inline_script( 'media-widgets', 'wp.mediaWidgets.init();', 'after' );
 
 	$scripts->add( 'media-image-widget', plugin_dir_url( __FILE__ ) . 'wp-admin/js/widgets/media-image-widget.js', array( 'media-widgets' ) );
 	// @todo $scripts->add( 'media-video-widget', plugin_dir_url( __FILE__ ) . 'wp-admin/js/widgets/media-image-widget.js', array( 'media-widgets', 'wp-mediaelement' ) );

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -134,6 +134,10 @@
 			} );
 
 			updateCallback = function( imageData ) {
+
+				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
+				control.selectedAttachment.set( mediaFrame.state().attributes.image.attachment.attributes );
+
 				control.model.set( {
 					attachment_id: imageData.attachment_id,
 					url: imageData.url,
@@ -151,9 +155,6 @@
 					width: 'custom' === imageData.size ? imageData.customWidth : imageData.width,
 					height: 'custom' === imageData.size ? imageData.customHeight : imageData.height
 				} );
-
-				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				control.selectedAttachment.set( mediaFrame.state().attributes.image.attachment.attributes );
 			};
 
 			mediaFrame.state( 'image-details' ).on( 'update', updateCallback );

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -4,9 +4,24 @@
 
 	var ImageWidgetModel, ImageWidgetControl;
 
-	// Defaults will get set via WP_Widget_Image::enqueue_admin_scripts().
+	/**
+	 * Image widget model.
+	 *
+	 * See WP_Widget_Image::enqueue_admin_scripts() for amending prototype from PHP exports.
+	 *
+	 * @class ImageWidgetModel
+	 * @constructor
+	 */
 	ImageWidgetModel = component.MediaWidgetModel.extend( {} );
 
+	/**
+	 * Image widget control.
+	 *
+	 * See WP_Widget_Image::enqueue_admin_scripts() for amending prototype from PHP exports.
+	 *
+	 * @class ImageWidgetModel
+	 * @constructor
+	 */
 	ImageWidgetControl = component.MediaWidgetControl.extend( {
 
 		/**

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -220,9 +220,6 @@ wp.mediaWidgets = ( function( $ ) {
 
 	component.MediaWidgetModel = Backbone.Model.extend( {
 		schema: {
-			id: {
-				type: 'string'
-			},
 			title: {
 				type: 'string',
 				'default': ''
@@ -280,6 +277,7 @@ wp.mediaWidgets = ( function( $ ) {
 			_.each( attrs, function( value, name ) { // eslint-disable-line complexity
 				var type;
 				if ( ! model.schema[ name ] ) {
+					castedAttrs[ name ] = value;
 					return;
 				}
 				type = model.schema[ name ].type;

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -155,7 +155,7 @@ wp.mediaWidgets = ( function( $ ) {
 			var control = this, titleInput;
 
 			if ( ! control.templateRendered ) {
-				control.$el.html( control.template( control.model.attributes ) );
+				control.$el.html( control.template()( control.model.attributes ) );
 				control.templateRendered = true;
 			}
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -4,27 +4,74 @@ wp.mediaWidgets = ( function( $ ) {
 
 	var component = {};
 
-	// Media widget subclasses assign subclasses of MediaWidgetControl onto this object by widget ID base.
+	/**
+	 * Widget control (view) constructors, mapping widget id_base to subclass of MediaWidgetControl.
+	 *
+	 * Media widgets register themselves by assigning subclasses of MediaWidgetControl onto this object by widget ID base.
+	 *
+	 * @type {Object.<string, wp.mediaWidgets.MediaWidgetModel>}
+	 */
 	component.controlConstructors = {};
+
+	/**
+	 * Widget model constructors, mapping widget id_base to subclass of MediaWidgetModel.
+	 *
+	 * Media widgets register themselves by assigning subclasses of MediaWidgetControl onto this object by widget ID base.
+	 *
+	 * @type {Object.<string, wp.mediaWidgets.MediaWidgetModel>}
+	 */
 	component.modelConstructors = {};
 
 	/**
 	 * Media widget control.
 	 *
+	 * @class MediaWidgetControl
 	 * @constructor
 	 * @abstract
 	 */
 	component.MediaWidgetControl = Backbone.View.extend( {
 
+		/**
+		 * Translation strings.
+		 *
+		 * The mapping of translation strings is handled by media widget subclasses,
+		 * exported from PHP to JS such as is done in WP_Widget_Image::enqueue_admin_scripts().
+		 *
+		 * @type {Object}
+		 */
 		l10n: {
 			add_to_widget: '{{add_to_widget}}',
 			select_media: '{{select_media}}'
 		},
 
+		/**
+		 * Widget ID base.
+		 *
+		 * This may be defined by the subclass. It may be exported from PHP to JS
+		 * such as is done in WP_Widget_Image::enqueue_admin_scripts(). If not,
+		 * it will attempt to be discovered by looking to see if this control
+		 * instance extends each member of component.controlConstructors, and if
+		 * it does extend one, will use the key as the id_base.
+		 *
+		 * @type {string}
+		 */
 		id_base: '',
 
+		/**
+		 * Mime type.
+		 *
+		 * This must be defined by the subclass. It may be exported from PHP to JS
+		 * such as is done in WP_Widget_Image::enqueue_admin_scripts().
+		 *
+		 * @type {string}
+		 */
 		mime_type: '',
 
+		/**
+		 * View events.
+		 *
+		 * @type {Object}
+		 */
 		events: {
 			'click .select-media': 'selectMedia',
 			'click .edit-media': 'editMedia'
@@ -33,7 +80,7 @@ wp.mediaWidgets = ( function( $ ) {
 		/**
 		 * Initialize.
 		 *
-		 * @param {object}         options - Options.
+		 * @param {Object}         options - Options.
 		 * @param {Backbone.Model} options.model - Model.
 		 * @param {function}       options.template - Control template.
 		 * @param {jQuery}         options.el - Control container element.
@@ -202,7 +249,7 @@ wp.mediaWidgets = ( function( $ ) {
 		 * Get the instance props from the media selection frame.
 		 *
 		 * @param {wp.media.view.MediaFrame.Select} mediaFrame Select frame.
-		 * @return {object} Props.
+		 * @return {Object} Props.
 		 */
 		getSelectFrameProps: function getSelectFrameProps( mediaFrame ) {
 			var attachment, props;
@@ -231,7 +278,22 @@ wp.mediaWidgets = ( function( $ ) {
 		}
 	} );
 
+	/**
+	 * Media widget model.
+	 *
+	 * @class MediaWidgetModel
+	 * @constructor
+	 */
 	component.MediaWidgetModel = Backbone.Model.extend( {
+
+		/**
+		 * Instance schema.
+		 *
+		 * This adheres to JSON Schema and subclasses should have their schema
+		 * exported from PHP to JS such as is done in WP_Widget_Image::enqueue_admin_scripts().
+		 *
+		 * @param {Object.<string, Object>}
+		 */
 		schema: {
 			title: {
 				type: 'string',
@@ -250,7 +312,7 @@ wp.mediaWidgets = ( function( $ ) {
 		/**
 		 * Get default attribute values.
 		 *
-		 * @returns {object} Default values.
+		 * @returns {Object} Mapping of property names to their default values.
 		 */
 		defaults: function() {
 			var defaults = {};
@@ -267,9 +329,9 @@ wp.mediaWidgets = ( function( $ ) {
 		 * cast the attribute values from the hidden inputs' string values into
 		 * the appropriate data types (integers or booleans).
 		 *
-		 * @param {string|object} key       Attribute name or attribute pairs.
-		 * @param {mixed|object}  [val]     Attribute value or options object.
-		 * @param {object}        [options] Options when attribute name and value are passed separately.
+		 * @param {string|Object} key       Attribute name or attribute pairs.
+		 * @param {mixed|Object}  [val]     Attribute value or options object.
+		 * @param {Object}        [options] Options when attribute name and value are passed separately.
 		 * @return {wp.mediaWidgets.MediaWidgetModel} This model.
 		 */
 		set: function set( key, val, options ) {
@@ -307,9 +369,20 @@ wp.mediaWidgets = ( function( $ ) {
 		}
 	} );
 
+	/**
+	 * Collection of all widget model instances.
+	 *
+	 * @type {Backbone.Collection}
+	 */
 	component.modelCollection = new ( Backbone.Collection.extend( {
 		model: component.MediaWidgetModel
 	} ) )();
+
+	/**
+	 * Mapping of widget ID to instances of MediaWidgetControl subclasses.
+	 *
+	 * @type {Object.<string, wp.mediaWidgets.MediaWidgetControl>}
+	 */
 	component.widgetControls = {};
 
 	/**

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -362,6 +362,32 @@ wp.mediaWidgets = ( function( $ ) {
 	};
 
 	/**
+	 * Handle widget being updated after submission for saving (mainly on widgets admin screen).
+	 *
+	 * @param {jQuery.Event} event - Event.
+	 * @param {jQuery}       widgetContainer - Widget container element.
+	 * @returns {void}
+	 */
+	component.handleWidgetUpdated = function handleWidgetUpdated( event, widgetContainer ) {
+		var widgetForm, widgetContent, widgetId, widgetControl, attributes = {};
+		widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' );
+		widgetContent = widgetForm.find( '> .widget-content' );
+		widgetId = widgetForm.find( '> .widget-id' ).val();
+
+		widgetControl = component.widgetControls[ widgetId ];
+		if ( ! widgetControl ) {
+			return;
+		}
+
+		// Make sure the server-sanitized values get synced back into the model.
+		widgetContent.find( '.media-widget-instance-property' ).each( function() {
+			attributes[ $( this ).data( 'property' ) ] = $( this ).val();
+		} );
+		delete attributes.id; // Read only.
+		widgetControl.model.set( attributes );
+	};
+
+	/**
 	 * Initialize functionality.
 	 *
 	 * This function exists to prevent the JS file from having to boot itself.
@@ -372,6 +398,7 @@ wp.mediaWidgets = ( function( $ ) {
 	 */
 	component.init = function init() {
 		$( document ).on( 'widget-added', component.handleWidgetAdded );
+		$( document ).on( 'widget-updated', component.handleWidgetUpdated );
 
 		/*
 		 * Manually trigger widget-added events for media widgets on the admin

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -299,7 +299,7 @@ wp.mediaWidgets = ( function( $ ) {
 	 */
 	component.handleWidgetAdded = function handleWidgetAdded( event, widgetContainer ) {
 		var widgetContent, controlContainer, widgetForm, idBase, ControlConstructor, ModelConstructor, modelAttributes, widgetControl, widgetModel, widgetId;
-		widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' );
+		widgetForm = widgetContainer.find( '> .widget-inside > .form, > .widget-inside > form' ); // Note: '.form' appears in the customizer, whereas 'form' on the widgets admin screen.
 		widgetContent = widgetForm.find( '> .widget-content' );
 		idBase = widgetForm.find( '> .id_base' ).val();
 		widgetId = widgetForm.find( '> .widget-id' ).val();
@@ -374,8 +374,6 @@ wp.mediaWidgets = ( function( $ ) {
 		/*
 		 * Manually trigger widget-added events for media widgets on the admin
 		 * screen once they are expanded.
-		 *
-		 * @todo Widget title is now showing up on the widgets admin screen.
 		 */
 		$( function domReady() {
 			if ( 'widgets' === window.pagenow ) {

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -427,8 +427,9 @@ wp.mediaWidgets = ( function( $ ) {
 	 * @returns {void}
 	 */
 	component.init = function init() {
-		$( document ).on( 'widget-added', component.handleWidgetAdded );
-		$( document ).on( 'widget-synced widget-updated', component.handleWidgetUpdated );
+		var $document = $( document );
+		$document.on( 'widget-added', component.handleWidgetAdded );
+		$document.on( 'widget-synced widget-updated', component.handleWidgetUpdated );
 
 		/*
 		 * Manually trigger widget-added events for media widgets on the admin

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -45,7 +45,7 @@ wp.mediaWidgets = ( function( $ ) {
 			Backbone.View.prototype.initialize.call( control, options );
 
 			// Allow methods to be passed in with control context preserved.
-			_.bindAll( control, 'syncModelToInputs', 'render', 'fetchSelectedAttachment' );
+			_.bindAll( control, 'syncModelToInputs', 'render', 'fetchSelectedAttachment', 'renderPreview' );
 
 			if ( ! control.id_base ) {
 				_.find( component.controlConstructors, function( Constructor, idBase ) {
@@ -62,9 +62,7 @@ wp.mediaWidgets = ( function( $ ) {
 
 			// Re-render the preview when the attachment changes.
 			control.selectedAttachment = new wp.media.model.Attachment( { id: 0 } );
-			control.listenTo( control.selectedAttachment, 'change', function() {
-				control.renderPreview();
-			} );
+			control.listenTo( control.selectedAttachment, 'change', control.renderPreview );
 
 			// Make sure a copy of the selected attachment is always fetched.
 			control.model.on( 'change:attachment_id', control.fetchSelectedAttachment );

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -212,6 +212,9 @@ wp.mediaWidgets = ( function( $ ) {
 
 	component.MediaWidgetModel = Backbone.Model.extend( {
 		schema: {
+			id: {
+				type: 'string'
+			},
 			title: {
 				type: 'string',
 				'default': ''
@@ -335,13 +338,12 @@ wp.mediaWidgets = ( function( $ ) {
 		 * In the future, when widgets are JS-driven, the underlying widget instance data should be exposed as a model
 		 * from the start, without having to sync with hidden fields. See <https://core.trac.wordpress.org/ticket/33507>.
 		 */
-		modelAttributes = {
-			id: widgetId
-		};
+		modelAttributes = {};
 		widgetContent.find( '.media-widget-instance-property' ).each( function() {
 			var input = $( this );
 			modelAttributes[ input.data( 'property' ) ] = input.val();
 		} );
+		modelAttributes.id = widgetId;
 
 		widgetModel = new ModelConstructor( modelAttributes );
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -425,15 +425,16 @@ wp.mediaWidgets = ( function( $ ) {
 		 * the same for the widgets admin screen, to invoke the widget-added
 		 * handler when a pre-existing media widget is expanded.
 		 */
-		$( function domReady() {
-			if ( 'widgets' === window.pagenow ) {
-				$( '.widgets-holder-wrap:not(#available-widgets)' ).find( 'div.widget' ).one( 'click.media-widget-toggle', function() {
-					component.handleWidgetAdded(
-						new jQuery.Event( 'widget-added' ),
-						$( this )
-					);
-				} );
+		$( function initializeExistingWidgetContainers() {
+			var widgetContainers;
+			if ( 'widgets' !== window.pagenow ) {
+				return;
 			}
+			widgetContainers = $( '.widgets-holder-wrap:not(#available-widgets)' ).find( 'div.widget' );
+			widgetContainers.one( 'click.toggle-widget-expanded', function toggleWidgetExpanded() {
+				var widgetContainer = $( this );
+				component.handleWidgetAdded( new jQuery.Event( 'widget-added' ), widgetContainer );
+			} );
 		});
 	};
 

--- a/wp-includes/js/customize-selective-refresh-extras.js
+++ b/wp-includes/js/customize-selective-refresh-extras.js
@@ -7,7 +7,11 @@
 	 */
 	api.selectiveRefresh.bind( 'partial-content-rendered', function initializeMediaElements() {
 
-		// @todo If audio, first ensure that wp_audio_shortcode_library filters away mediaelement; if video, check wp_video_shortcode_library filters the same.
+		/*
+		 * Note that the 'wp_audio_shortcode_library' and 'wp_video_shortcode_library' filters
+		 * will determine whether or not wp.mediaelement is loaded and whether it will
+		 * initialize audio and video respectively. See also https://core.trac.wordpress.org/ticket/40144
+		 */
 		if ( wp.mediaelement ) {
 			wp.mediaelement.initialize();
 		}

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -153,9 +153,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 			if ( ! array_key_exists( $field, $new_instance ) ) {
 				continue;
 			}
-			if ( ! empty( $field_schema['readonly'] ) ) {
-				continue;
-			}
 			$value = $new_instance[ $field ];
 			if ( true !== rest_validate_value_from_schema( $value, $field_schema, $field ) ) {
 				continue;

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -224,7 +224,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 				data-property="<?php echo esc_attr( $name ); ?>"
 				class="media-widget-instance-property"
 				name="<?php echo esc_attr( $this->get_field_name( $name ) ); ?>"
-				value="<?php echo esc_attr( strval( $value ) ); // @todo Encode as JSON? ?>"
+				id="<?php echo esc_attr( $this->get_field_id( $name ) ); // Needed specifically by wpWidgets.appendTitle(). ?>"
+				value="<?php echo esc_attr( strval( $value ) ); ?>"
 			/>
 		<?php endforeach; ?>
 		<?php
@@ -275,7 +276,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 	public function render_control_template_scripts() {
 		?>
 		<script type="text/html" id="tmpl-widget-media-<?php echo $this->id_base; ?>-control">
-			<# var elementIdPrefix = 'el' + String( Math.random() ) + '-' #>
+			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_' #>
 			<p>
 				<label for="{{ elementIdPrefix }}title"><?php esc_html_e( 'Title:' ); ?></label>
 				<input id="{{ elementIdPrefix }}title" type="text" class="widefat title">

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -83,12 +83,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 */
 	protected function get_instance_schema() {
 		return array(
-			'id' => array(
-				'type' => 'string',
-				'readonly' => true,
-				'description' => __( 'Widget ID' ),
-				'default' => '',
-			),
 			'attachment_id' => array(
 				'type' => 'integer',
 				'default' => 0,

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -83,20 +83,29 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 */
 	protected function get_instance_schema() {
 		return array(
+			'id' => array(
+				'type' => 'string',
+				'readonly' => true,
+				'description' => __( 'Widget ID' ),
+				'default' => '',
+			),
 			'attachment_id' => array(
 				'type' => 'integer',
 				'default' => 0,
 				'minimum' => 0,
+				'description' => __( 'Attachment post ID' ),
 			),
 			'url' => array(
 				'type' => 'string',
 				'default' => '',
 				'format' => 'uri',
+				'description' => __( 'URL to the media file' ),
 			),
 			'title' => array(
 				'type' => 'string',
 				'default' => '',
 				'sanitize_callback' => 'sanitize_text_field',
+				'description' => __( 'Title for the widget' ),
 			),
 		);
 	}
@@ -132,7 +141,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	/**
 	 * Sanitizes the widget form values as they are saved.
 	 *
-	 * @todo This method could read from an instance property schema definitions to apply sanitize callbacks.
 	 * @since 4.8.0
 	 * @access public
 	 *
@@ -149,6 +157,9 @@ abstract class WP_Widget_Media extends WP_Widget {
 		$schema = $this->get_instance_schema();
 		foreach ( $schema as $field => $field_schema ) {
 			if ( ! array_key_exists( $field, $new_instance ) ) {
+				continue;
+			}
+			if ( ! empty( $field_schema['readonly'] ) ) {
 				continue;
 			}
 			$value = $new_instance[ $field ];
@@ -215,7 +226,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 		$instance_schema = $this->get_instance_schema();
 		$instance = wp_array_slice_assoc(
 			wp_parse_args( (array) $instance, wp_list_pluck( $instance_schema, 'default' ) ),
-			array_keys( wp_list_pluck( $instance_schema, 'default' ) )
+			array_keys( $instance_schema )
 		);
 		?>
 		<?php foreach ( $instance as $name => $value ) : ?>


### PR DESCRIPTION
PR currently targeting merge into feature branch for still-open #18. Once merged, target branch can be changed to `master`.

* Improves JS initialization logic, removing self-booting JS and improving structure.
* Add syncing of server-sanitized widget data into Backbone model upon `widget-updated`.