### PR TITLE
Pre-populate attachment display settings in select frame with widget instance state

### DIFF
--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -80,7 +80,7 @@
 		 * @returns {void}
 		 */
 		selectMedia: function selectMedia( event ) {
-			var control = this, selection, mediaFrame, library, CustomizedDisplaySettingsLibrary, customizedDisplaySettings;
+			var control = this, selection, mediaFrame, CustomizedDisplaySettingsLibrary, customizedDisplaySettings;
 
 			event.preventDefault();
 
@@ -142,24 +142,22 @@
 				}
 			} );
 
-			library = new CustomizedDisplaySettingsLibrary( {
-				library: wp.media.query( {
-					type: control.mime_type
-				} ),
-				title: control.l10n.select_media,
-				selection: selection,
-				multiple: false,
-				priority: 20,
-				display: true, // Attachment display setting.
-				filterable: false
-			} );
-
 			mediaFrame = wp.media( {
 				frame: 'select',
 				button: {
 					text: control.l10n.add_to_widget
 				},
-				states: library
+				states: new CustomizedDisplaySettingsLibrary( {
+					library: wp.media.query( {
+						type: control.mime_type
+					} ),
+					title: control.l10n.select_media,
+					selection: selection,
+					multiple: false,
+					priority: 20,
+					display: true, // Attachment display setting.
+					filterable: false
+				} )
 			} );
 
 			// Handle selection of a media item.

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -165,11 +165,6 @@
 				url: control.model.get( 'url' )
 			};
 
-			wp.media.events.trigger( 'editor:image-edit', {
-				metadata: metadata,
-				image: control.$el.find( 'img:first' )
-			} );
-
 			// Set up the media frame.
 			mediaFrame = wp.media({
 				frame: 'image',

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -114,8 +114,7 @@
 
 			mediaFrame.open();
 
-			// @todo There must be a better way to access this view.
-			displaySettingsView = mediaFrame.views.get( '.media-frame-content' )[0].sidebar._views.display;
+			displaySettingsView = mediaFrame.views.get( '.media-frame-content' )[0].sidebar.get( 'display' );
 
 			displaySettingsView.model.set( {
 				align: control.model.get( 'align' ),

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -79,7 +79,7 @@
 		 * @returns {void}
 		 */
 		selectMedia: function selectMedia() {
-			var control = this, selection, mediaFrame;
+			var control = this, selection, mediaFrame, displaySettingsView;
 
 			selection = new wp.media.model.Selection( [ control.selectedAttachment ] );
 
@@ -113,6 +113,21 @@
 			} );
 
 			mediaFrame.open();
+
+			// @todo There must be a better way to access this view.
+			displaySettingsView = mediaFrame.views.get( '.media-frame-content' )[0].sidebar._views.display;
+
+			displaySettingsView.model.set( {
+				align: control.model.get( 'align' ),
+				linkUrl: control.model.get( 'link_url' ),
+				size: control.model.get( 'size' )
+			} );
+
+			/*
+			 * Set link type last due to AttachmentDisplay.updateLinkTo() blowing
+			 * the linkUrl if linkUrl change gets made before the link change.
+			 */
+			displaySettingsView.model.set( 'link', control.model.get( 'link_type' ) );
 		},
 
 		/**

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -128,6 +128,15 @@
 			 * the linkUrl if linkUrl change gets made before the link change.
 			 */
 			displaySettingsView.model.set( 'link', control.model.get( 'link_type' ) );
+
+			/*
+			 * Make sure focus is set inside of modal so that hitting Esc will close
+			 * the modal and not inadvertently cause the widget to collapse in the
+			 * customizer. Setting the focus is also needed here because the
+			 * AttachmentDisplay.updateLinkTo() function will set focus on the
+			 * linkUrl input when the link changes above.
+			 */
+			mediaFrame.$el.find( ':focusable:first' ).focus();
 		},
 
 		/**
@@ -136,7 +145,7 @@
 		 * @returns {void}
 		 */
 		editMedia: function editMedia() {
-			var control = this, mediaFrame, metadata, updateCallback;
+			var control = this, mediaFrame, metadata, updateCallback, mediaFrameContentView;
 
 			metadata = {
 				attachment_id: control.model.get( 'attachment_id' ),
@@ -199,6 +208,18 @@
 			});
 
 			mediaFrame.open();
+
+			/*
+			 * Make sure focus is set inside of modal so that hitting Esc will close
+			 * the modal and not inadvertently cause the widget to collapse in the
+			 * customizer.
+			 */
+			mediaFrameContentView = mediaFrame.views.get( '.media-frame-content' )[0];
+			mediaFrameContentView.model.dfd.done( function() {
+				_.defer( function() { // Next tick.
+					mediaFrameContentView.$el.find( '[data-setting="caption"]:first' ).focus();
+				} );
+			} );
 		}
 	} );
 


### PR DESCRIPTION
To preserve previously-supplied attachment display settings, restore them when opening the media frame to change the selected image.

Also focus on first focusable element select and edit media frames for improved accessibility.