### PR TITLE
Ensure preview image in control is center-aligned and does not overflow

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -30,3 +30,6 @@
 .media-widget-control .media-widget-preview {
 	text-align: center;
 }
+.media-widget-control .media-widget-preview img {
+	max-width: 100%;
+}

--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -27,3 +27,6 @@
 .media-widget-buttons .button:first-child {
 	margin-left: 0;
 }
+.media-widget-control .media-widget-preview {
+	text-align: center;
+}


### PR DESCRIPTION
Fixes #24.

Centers image that is smaller than the control width:

<img width="441" alt="screen shot 2017-03-15 at 21 53 42" src="https://cloud.githubusercontent.com/assets/134745/23982467/de631d8e-09ca-11e7-8098-fe6b1b53acf2.png">

And adds `max-width` to prevent an image that is wider than the control from overflowing:

<img width="446" alt="screen shot 2017-03-15 at 21 59 39" src="https://cloud.githubusercontent.com/assets/134745/23982479/f0d78040-09ca-11e7-8029-4a4caa474839.png">

