### PR TITLE
Handle deletion of attachment associated with media widget

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -1,4 +1,3 @@
-
 .media-widget-control.selected .not-selected,
 .media-widget-control:not(.selected) .selected {
 	display: none;
@@ -43,6 +42,9 @@
 
 .media-widget-control .media-widget-preview {
 	text-align: center;
+}
+.media-widget-control .media-widget-preview .notice {
+	text-align: initial;
 }
 .media-widget-control .media-widget-preview img {
 	max-width: 100%;

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -109,6 +109,7 @@
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
 				attachment = mediaFrame.state().get( 'selection' ).first().toJSON();
+				attachment.error = false;
 				control.selectedAttachment.set( attachment );
 
 				// Update widget instance.
@@ -157,9 +158,12 @@
 			} );
 
 			updateCallback = function( imageData ) {
+				var attachment;
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				control.selectedAttachment.set( mediaFrame.state().attributes.image.attachment.attributes );
+				attachment = mediaFrame.state().attributes.image.toJSON();
+				attachment.error = false;
+				control.selectedAttachment.set( attachment );
 
 				control.model.set( {
 					attachment_id: imageData.attachment_id,

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -117,6 +117,16 @@
 			} );
 
 			mediaFrame.open();
+
+			// Clear the selected attachment when it is deleted in the media select frame.
+			selection.on( 'destroy', function( attachment ) {
+				if ( control.model.get( 'attachment_id' ) === attachment.get( 'id' ) ) {
+					control.model.set( {
+						attachment_id: 0,
+						url: ''
+					} );
+				}
+			} );
 		},
 
 		/**

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -76,10 +76,13 @@
 		/**
 		 * Open the media select frame to chose an item.
 		 *
+		 * @param {jQuery.Event} event - Event.
 		 * @returns {void}
 		 */
-		selectMedia: function selectMedia() {
+		selectMedia: function selectMedia( event ) {
 			var control = this, selection, mediaFrame;
+
+			event.preventDefault();
 
 			selection = new wp.media.model.Selection( [ control.selectedAttachment ] );
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -73,7 +73,7 @@ wp.mediaWidgets = ( function( $ ) {
 		 * @type {Object}
 		 */
 		events: {
-			'click .notice a': 'selectMedia',
+			'click .notice-missing-attachment a': 'selectMedia',
 			'click .select-media': 'selectMedia',
 			'click .edit-media': 'editMedia'
 		},
@@ -155,10 +155,10 @@ wp.mediaWidgets = ( function( $ ) {
 				} );
 				attachment.fetch()
 					.done( function() {
-						control.selectedAttachment.set( attachment.attributes );
+						control.selectedAttachment.set( _.extend( {}, attachment.attributes, { error: false } ) );
 					} )
 					.fail( function() {
-						control.selectedAttachment.set( { error: true } );
+						control.selectedAttachment.set( { error: 'missing_attachment' } );
 					} );
 			}
 		},

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -152,9 +152,13 @@ wp.mediaWidgets = ( function( $ ) {
 				attachment = new wp.media.model.Attachment( {
 					id: control.model.get( 'attachment_id' )
 				} );
-				attachment.fetch().done( function() {
-					control.selectedAttachment.set( attachment.attributes );
-				} );
+				attachment.fetch()
+					.done( function() {
+						control.selectedAttachment.set( attachment.attributes );
+					} )
+					.fail( function() {
+						control.selectedAttachment.set( { error: true } );
+					} );
 			}
 		},
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -73,6 +73,7 @@ wp.mediaWidgets = ( function( $ ) {
 		 * @type {Object}
 		 */
 		events: {
+			'click .notice a': 'selectMedia',
 			'click .select-media': 'selectMedia',
 			'click .edit-media': 'editMedia'
 		},

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -36,8 +36,8 @@ class WP_Widget_Image extends WP_Widget_Media {
 				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
-			/* translators: %s is widget count */
-			'media_library_state' => _n_noop( 'Image Widget', 'Image Widget (%s)' ),
+			/* translators: %d is widget count */
+			'media_library_state' => _n_noop( 'Image Widget (%d instance)', 'Image Widget (%d instances)' ),
 			'no_media_selected' => __( 'No image selected' ),
 			'select_media' => __( 'Select Image' ),
 		) );

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -34,8 +34,6 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
 		) );
-
-		add_filter( 'display_media_states', array( $this, 'display_media_state' ), 10, 2 );
 	}
 
 	/**
@@ -212,41 +210,6 @@ class WP_Widget_Image extends WP_Widget_Media {
 		}
 
 		echo $image;
-	}
-
-	/**
-	 * Filters the default media display states for items in the Media list table.
-	 *
-	 * @since 4.8.0
-	 * @access public
-	 *
-	 * @param array   $states An array of media states.
-	 * @param WP_Post $post   The current attachment object.
-	 * @return array
-	 */
-	public function display_media_state( $states, $post ) {
-
-		// Short-circuit if the post is not an image attachment.
-		if ( 'attachment' !== $post->post_type || 0 !== strpos( $post->post_mime_type, 'image/' ) ) {
-			return $states;
-		}
-
-		// Count how many times this image attachment is used in image widgets.
-		$image_used_count = 0;
-		foreach ( $this->get_settings() as $instance ) {
-			if ( isset( $instance['attachment_id'] ) && $instance['attachment_id'] === $post->ID ) {
-				$image_used_count++;
-			}
-		}
-
-		if ( $image_used_count > 1 ) {
-			/* translators: %d is widget count */
-			$states[] = sprintf( __( 'Image Widgets (%d)' ), $image_used_count );
-		} elseif ( 1 === $image_used_count ) {
-			$states[] = __( 'Image Widget' );
-		}
-
-		return $states;
 	}
 
 	/**

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -33,7 +33,10 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'edit_media' => __( 'Edit Image' ),
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
-			'error' => __( 'Image could not be loaded. Please verify it was not deleted.' ),
+			'error' => sprintf(
+				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
+				esc_url( admin_url( 'upload.php' ) )
+			),
 		) );
 	}
 
@@ -269,7 +272,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 				<img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false" alt="" />
 			<# } else if ( data.attachment.error ) { #>
 				<div class="notice notice-error notice-alt">
-					<p><?php echo esc_html( $this->l10n['error'] ); ?></p>
+					<p><?php echo $this->l10n['error']; ?></p>
 				</div>
 			<# } #>
 		</script>

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -33,6 +33,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'edit_media' => __( 'Edit Image' ),
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
+			'error' => __( 'Image could not be loaded. Please verify it was not deleted.' ),
 		) );
 	}
 
@@ -266,6 +267,10 @@ class WP_Widget_Image extends WP_Widget_Media {
 				<img class="attachment-thumb" src="{{ data.attachment.sizes.medium.url }}" draggable="false" alt="" />
 			<# } else if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.full ) { #>
 				<img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false" alt="" />
+			<# } else if ( data.attachment.error ) { #>
+				<div class="notice notice-error notice-alt">
+					<p><?php echo esc_html( $this->l10n['error'] ); ?></p>
+				</div>
 			<# } #>
 		</script>
 		<?php

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -31,7 +31,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 		$this->l10n = array_merge( $this->l10n, array(
 			'change_media' => __( 'Change Image' ),
 			'edit_media' => __( 'Edit Image' ),
-			'error' => sprintf(
+			'missing_attachment' => sprintf(
 				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
@@ -271,9 +271,9 @@ class WP_Widget_Image extends WP_Widget_Media {
 				<img class="attachment-thumb" src="{{ data.attachment.sizes.medium.url }}" draggable="false" alt="" />
 			<# } else if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.full ) { #>
 				<img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false" alt="" />
-			<# } else if ( data.attachment.error ) { #>
-				<div class="notice notice-error notice-alt">
-					<p><?php echo $this->l10n['error']; ?></p>
+			<# } else if ( data.attachment.error && data.attachment.error.missing_attachment ) { #>
+				<div class="notice notice-error notice-alt notice-missing-attachment">
+					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
 			<# } #>
 		</script>

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -35,7 +35,8 @@ class WP_Widget_Image extends WP_Widget_Media {
 				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
-			'media_library_state' => __( 'Image Widget' ),
+			/* translators: %s is widget count */
+			'media_library_state' => _n_noop( 'Image Widget', 'Image Widget (%s)' ),
 			'no_media_selected' => __( 'No image selected' ),
 			'select_media' => __( 'Select Image' ),
 		) );

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -269,7 +269,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 
 		?>
 		<script type="text/html" id="tmpl-wp-media-widget-image-preview">
-			<# if ( data.attachment.error && data.attachment.error.missing_attachment ) { #>
+			<# if ( data.attachment.error && 'missing_attachment' === data.attachment.error ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -32,6 +32,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'change_media' => __( 'Change Image' ),
 			'edit_media' => __( 'Edit Image' ),
 			'missing_attachment' => sprintf(
+				/* translators: placeholder is URL to media library */
 				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -34,6 +34,8 @@ class WP_Widget_Image extends WP_Widget_Media {
 			'change_media' => __( 'Change Image' ),
 			'select_media' => __( 'Select Image' ),
 		) );
+
+		add_filter( 'display_media_states', array( $this, 'display_media_state' ), 10, 2 );
 	}
 
 	/**
@@ -210,6 +212,27 @@ class WP_Widget_Image extends WP_Widget_Media {
 		}
 
 		echo $image;
+	}
+
+	/**
+	 * Filters the default media display states for items in the Media list table.
+	 *
+	 * @since 4.8.0
+	 * @access public
+	 *
+	 * @param array   $states An array of media states.
+	 * @param WP_Post $post   The current attachment object.
+	 * @return array
+	 */
+	public function display_media_state( $states, $post ) {
+		$settings      = $this->get_settings();
+		$attachment_id = empty( $settings[ $this->number ]['attachment_id'] ) ? 0 : $settings[ $this->number ]['attachment_id'];
+
+		if ( $attachment_id === $post->ID ) {
+			$states[] = __( 'Image Widget' );
+		}
+
+		return $states;
 	}
 
 	/**

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -269,14 +269,18 @@ class WP_Widget_Image extends WP_Widget_Media {
 
 		?>
 		<script type="text/html" id="tmpl-wp-media-widget-image-preview">
-			<# if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.medium ) { #>
-				<img class="attachment-thumb" src="{{ data.attachment.sizes.medium.url }}" draggable="false" alt="" />
-			<# } else if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.full ) { #>
-				<img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false" alt="" />
-			<# } else if ( data.attachment.error && data.attachment.error.missing_attachment ) { #>
+			<# if ( data.attachment.error && data.attachment.error.missing_attachment ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
+			<# } else if ( data.attachment.error ) { #>
+				<div class="notice notice-error notice-alt">
+					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
+				</div>
+			<# } else if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.medium ) { #>
+				<img class="attachment-thumb" src="{{ data.attachment.sizes.medium.url }}" draggable="false" alt="" />
+			<# } else if ( 'image' === data.attachment.type && data.attachment.sizes && data.attachment.sizes.full ) { #>
+				<img class="attachment-thumb" src="{{ data.attachment.sizes.full.url }}" draggable="false" alt="" />
 			<# } #>
 		</script>
 		<?php

--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -29,14 +29,15 @@ class WP_Widget_Image extends WP_Widget_Media {
 		) );
 
 		$this->l10n = array_merge( $this->l10n, array(
-			'no_media_selected' => __( 'No image selected' ),
-			'edit_media' => __( 'Edit Image' ),
 			'change_media' => __( 'Change Image' ),
-			'select_media' => __( 'Select Image' ),
+			'edit_media' => __( 'Edit Image' ),
 			'error' => sprintf(
 				__( 'We can&#8217;t find that image. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
+			'media_library_state' => __( 'Image Widget' ),
+			'no_media_selected' => __( 'No image selected' ),
+			'select_media' => __( 'Select Image' ),
 		) );
 	}
 

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -60,6 +60,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 			'edit_media' => __( 'Edit Media' ),
 			'media_library_state' => __( 'Media Widget' ),
 			'missing_attachment' => sprintf(
+				/* translators: placeholder is URL to media library */
 				__( 'We can&#8217;t find that file. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -23,11 +23,13 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @var array
 	 */
 	public $l10n = array(
-		'no_media_selected' => '',
-		'edit_media' => '',
-		'change_media' => '',
-		'select_media' => '',
 		'add_to_widget' => '',
+		'change_media' => '',
+		'edit_media' => '',
+		'error' => '',
+		'media_library_state' => '',
+		'no_media_selected' => '',
+		'select_media' => '',
 	);
 
 	/**
@@ -53,15 +55,16 @@ abstract class WP_Widget_Media extends WP_Widget {
 		$control_opts = wp_parse_args( $control_options, array() );
 
 		$l10n_defaults = array(
-			'no_media_selected' => __( 'No media selected' ),
-			'edit_media' => __( 'Edit Media' ),
-			'change_media' => __( 'Change Media' ),
-			'select_media' => __( 'Select Media' ),
 			'add_to_widget' => __( 'Add to Widget' ),
+			'change_media' => __( 'Change Media' ),
+			'edit_media' => __( 'Edit Media' ),
 			'error' => sprintf(
 				__( 'We can&#8217;t find that file. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
+			'media_library_state' => __( 'Media Widget' ),
+			'no_media_selected' => __( 'No media selected' ),
+			'select_media' => __( 'Select Media' ),
 		);
 		$this->l10n = array_merge( $l10n_defaults, array_filter( $this->l10n ) );
 
@@ -264,7 +267,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 			/* translators: %d is widget count */
 			$states[] = sprintf( __( 'Media Widgets (%d)' ), $use_count );
 		} elseif ( 1 === $use_count ) {
-			$states[] = $this->name;
+			$states[] = $this->l10n['media_library_state'];
 		}
 
 		return $states;

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -264,7 +264,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 		}
 
 		if ( $use_count > 0 ) {
-			$states[] = translate_nooped_plural( $this->l10n['media_library_state'], number_format_i18n( $use_count ) );
+			$states[] = sprintf( translate_nooped_plural( $this->l10n['media_library_state'], $use_count ), number_format_i18n( $use_count ) );
 		}
 
 		return $states;

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -263,11 +263,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 			}
 		}
 
-		if ( $use_count > 1 ) {
-			/* translators: %d is widget count */
-			$states[] = sprintf( __( 'Media Widgets (%d)' ), $use_count );
-		} elseif ( 1 === $use_count ) {
-			$states[] = $this->l10n['media_library_state'];
+		if ( $use_count > 0 ) {
+			$states[] = translate_nooped_plural( $this->l10n['media_library_state'], number_format_i18n( $use_count ) );
 		}
 
 		return $states;

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -26,8 +26,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 		'add_to_widget' => '',
 		'change_media' => '',
 		'edit_media' => '',
-		'error' => '',
 		'media_library_state' => '',
+		'missing_attachment' => '',
 		'no_media_selected' => '',
 		'select_media' => '',
 	);
@@ -58,11 +58,11 @@ abstract class WP_Widget_Media extends WP_Widget {
 			'add_to_widget' => __( 'Add to Widget' ),
 			'change_media' => __( 'Change Media' ),
 			'edit_media' => __( 'Edit Media' ),
-			'error' => sprintf(
+			'media_library_state' => __( 'Media Widget' ),
+			'missing_attachment' => sprintf(
 				__( 'We can&#8217;t find that file. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
 				esc_url( admin_url( 'upload.php' ) )
 			),
-			'media_library_state' => __( 'Media Widget' ),
 			'no_media_selected' => __( 'No media selected' ),
 			'select_media' => __( 'Select Media' ),
 		);

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -58,6 +58,10 @@ abstract class WP_Widget_Media extends WP_Widget {
 			'change_media' => __( 'Change Media' ),
 			'select_media' => __( 'Select Media' ),
 			'add_to_widget' => __( 'Add to Widget' ),
+			'error' => sprintf(
+				__( 'We can&#8217;t find that file. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),
+				esc_url( admin_url( 'upload.php' ) )
+			),
 		);
 		$this->l10n = array_merge( $l10n_defaults, array_filter( $this->l10n ) );
 

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -58,7 +58,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 			'add_to_widget' => __( 'Add to Widget' ),
 			'change_media' => __( 'Change Media' ),
 			'edit_media' => __( 'Edit Media' ),
-			'media_library_state' => __( 'Media Widget' ),
+			/* translators: %d is widget count */
+			'media_library_state' => _n_noop( 'Media Widget (%d instance)', 'Media Widget (%d instances)' ),
 			'missing_attachment' => sprintf(
 				/* translators: placeholder is URL to media library */
 				__( 'We can&#8217;t find that file. Check your <a href="%s">media library</a> and make sure it wasn&#8217;t deleted.' ),


### PR DESCRIPTION
Shows an error message in the media widget when its associated attachment is deleted.

Also adds a label to the attachment in the media list, when its used in a widget.

Fixes #22.

/cc @timmyc