### PR TITLE
Add corrective styles for default themes

### DIFF
--- a/core-media-widgets.php
+++ b/core-media-widgets.php
@@ -52,6 +52,30 @@ function wp32417_default_styles( WP_Styles $styles ) {
 add_action( 'wp_default_styles', 'wp32417_default_styles' );
 
 /**
+ * Style fixes for default themes.
+ */
+function wp32417_custom_theme_styles() {
+	if ( wp_style_is( 'twentysixteen-style' ) ) {
+		wp_add_inline_style( 'twentysixteen-style', '
+			.widget:before,.widget:after { content: ""; display: table; }
+			.widget:after { clear: both; }
+		' );
+	}
+
+	if ( 'twentyten' === get_template() ) {
+		add_action( 'wp_head', 'wp32417_twentyten_styles' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'wp32417_custom_theme_styles', 11 );
+
+/**
+ * Style fixes for Twenty Ten.
+ */
+function wp32417_twentyten_styles() {
+	echo '<style>.widget-container .wp-caption { max-width: 100% !important; }</style>';
+}
+
+/**
  * Register widget.
  */
 function wp32417_widgets_init() {


### PR DESCRIPTION
Twenty Ten doesn’t handle overflowing captions correctly.
Twenty Sixteen doesn’t clear floats inside widgets.

See https://github.com/xwp/wp-core-media-widgets/issues/13#issuecomment-287405452
Fixes #13.