### PR TITLE
Add translation context for widget buttons to constrain length

### DIFF
--- a/wp-includes/widgets/class-wp-widget-image.php
+++ b/wp-includes/widgets/class-wp-widget-image.php
@@ -30,9 +30,9 @@ class WP_Widget_Image extends WP_Widget_Media {
 
 		$this->l10n = array_merge( $this->l10n, array(
 			'no_media_selected' => __( 'No image selected' ),
-			'edit_media' => __( 'Edit Image' ),
-			'change_media' => __( 'Change Image' ),
-			'select_media' => __( 'Select Image' ),
+			'edit_media' => _x( 'Edit Image', 'label for button in the image widget; should not be longer than ~13 characters long' ),
+			'change_media' => _x( 'Change Image', 'label for button in the image widget; should not be longer than ~13 characters long' ),
+			'select_media' => _x( 'Select Image', 'label for button in the image widget; should not be longer than ~13 characters long' ),
 		) );
 	}
 
@@ -170,7 +170,7 @@ class WP_Widget_Image extends WP_Widget_Media {
 		}
 
 		$size = $instance['size'];
-		if ( 'custom' === $size || ! in_array( $size, array_merge( get_intermediate_image_sizes(), array( 'full' ) ) ) ) {
+		if ( 'custom' === $size || ! in_array( $size, array_merge( get_intermediate_image_sizes(), array( 'full' ) ), true ) ) {
 			$size = array( $instance['width'], $instance['height'] );
 		}
 

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -54,9 +54,9 @@ abstract class WP_Widget_Media extends WP_Widget {
 
 		$l10n_defaults = array(
 			'no_media_selected' => __( 'No media selected' ),
-			'edit_media' => __( 'Edit Media' ),
-			'change_media' => __( 'Change Media' ),
-			'select_media' => __( 'Select Media' ),
+			'edit_media' => _x( 'Edit Media', 'label for button in the media widget; should not be longer than ~13 characters long' ),
+			'change_media' => _x( 'Change Media', 'label for button in the media widget; should not be longer than ~13 characters long' ),
+			'select_media' => _x( 'Select Media', 'label for button in the media widget; should not be longer than ~13 characters long' ),
 			'add_to_widget' => __( 'Add to Widget' ),
 		);
 		$this->l10n = array_merge( $l10n_defaults, array_filter( $this->l10n ) );


### PR DESCRIPTION
Fixes #15.
Supersedes #23.

Translators have to know the context and know the size of the string they choose. This is indicated via the `$context` parameter in the translation function. This is what we did for the “Hide Controls” label in [#38762](https://core.trac.wordpress.org/ticket/38762). See [r39214](https://core.trac.wordpress.org/changeset/39214).