### PR TITLE
Ensure proper context on handleDisplaySettingChange

### DIFF
--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -31,6 +31,17 @@ wp.mediaWidgets = ( function( $ ) {
 	component.PersistentDisplaySettingsLibrary = wp.media.controller.Library.extend( {
 
 		/**
+		 * Initialize.
+		 *
+		 * @param {object} options Options.
+		 * @returns {void}
+		 */
+		initialize: function( options ) {
+			_.bindAll( this, 'handleDisplaySettingChange' );
+			wp.media.controller.Library.prototype.initialize.call( this, options );
+		},
+
+		/**
 		 * Sync changes to the current display settings back into the current customized
 		 *
 		 * @param {Backbone.Model} displaySettings Modified display settings.


### PR DESCRIPTION
I was finding that `this.get( 'selectedDisplaySettings' ).set( displaySettings.attributes );` would fail because `this` was the `Model` changed and not the `PersistentDisplaySettingsLibrary` instance.

Amends #58