### PR TITLE
Harden logic for rendering preview

### DIFF
--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -189,10 +189,10 @@
 
 			// Disable syncing of attachment changes back to server. See <https://core.trac.wordpress.org/ticket/40403>.
 			defaultSync = wp.media.model.Attachment.prototype.sync;
-			wp.media.model.Attachment.prototype.sync = function() {
+			wp.media.model.Attachment.prototype.sync = function rejectedSync() {
 				return $.Deferred().rejectWith( this ).promise();
 			};
-			mediaFrame.on( 'close', function() {
+			mediaFrame.on( 'close', function onClose() {
 				mediaFrame.detach();
 				wp.media.model.Attachment.prototype.sync = defaultSync;
 			});

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -162,9 +162,9 @@
 				var attachment;
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				attachment = mediaFrame.state().attributes.image.toJSON();
-				attachment.error = false;
-				control.selectedAttachment.set( attachment );
+				attachment = mediaFrame.state().attributes.image;
+				control.selectedAttachment.set( attachment.toJSON() );
+				control.model.set( 'error', false );
 
 				control.model.set( {
 					attachment_id: imageData.attachment_id,

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -735,7 +735,6 @@ wp.mediaWidgets = ( function( $ ) {
 			var property = $( this ).data( 'property' );
 			attributes[ property ] = $( this ).val();
 		} );
-		delete attributes.id; // Read only.
 
 		// Suspend syncing model back to inputs when syncing from inputs to model, preventing infinite loop.
 		widgetControl.stopListening( widgetControl.model, 'change', widgetControl.syncModelToInputs );

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -36,7 +36,7 @@ wp.mediaWidgets = ( function( $ ) {
 		 * @param {object} options Options.
 		 * @returns {void}
 		 */
-		initialize: function( options ) {
+		initialize: function initialize( options ) {
 			_.bindAll( this, 'handleDisplaySettingChange' );
 			wp.media.controller.Library.prototype.initialize.call( this, options );
 		},
@@ -141,7 +141,7 @@ wp.mediaWidgets = ( function( $ ) {
 				 * @fires wp.media.controller.State#insert()
 				 * @returns {void}
 				 */
-				click: function() {
+				click: function onClick() {
 					var state = controller.state(),
 						selection = state.get( 'selection' );
 
@@ -281,7 +281,7 @@ wp.mediaWidgets = ( function( $ ) {
 			control.listenTo( control.model, 'change', control.render );
 
 			// Update the title.
-			control.$el.on( 'input', '.title', function() {
+			control.$el.on( 'input', '.title', function updateTitle() {
 				control.model.set( {
 					title: $.trim( $( this ).val() )
 				} );
@@ -473,7 +473,7 @@ wp.mediaWidgets = ( function( $ ) {
 
 			// Disable syncing of attachment changes back to server. See <https://core.trac.wordpress.org/ticket/40403>.
 			defaultSync = wp.media.model.Attachment.prototype.sync;
-			wp.media.model.Attachment.prototype.sync = function() {
+			wp.media.model.Attachment.prototype.sync = function rejectedSync() {
 				return $.Deferred().rejectWith( this ).promise();
 			};
 			mediaFrame.on( 'close', function onClose() {
@@ -484,7 +484,7 @@ wp.mediaWidgets = ( function( $ ) {
 			mediaFrame.open();
 
 			// Clear the selected attachment when it is deleted in the media select frame.
-			selection.on( 'destroy', function( attachment ) {
+			selection.on( 'destroy', function onDestroy( attachment ) {
 				if ( control.model.get( 'attachment_id' ) === attachment.get( 'id' ) ) {
 					control.model.set( {
 						attachment_id: 0,

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -246,7 +246,7 @@ wp.mediaWidgets = ( function( $ ) {
 			}
 
 			// Allow methods to be passed in with control context preserved.
-			_.bindAll( control, 'syncModelToInputs', 'render', 'fetchSelectedAttachment', 'renderPreview' );
+			_.bindAll( control, 'syncModelToInputs', 'render', 'updateSelectedAttachment', 'renderPreview' );
 
 			if ( ! control.id_base ) {
 				_.find( component.controlConstructors, function( Constructor, idBase ) {
@@ -262,14 +262,15 @@ wp.mediaWidgets = ( function( $ ) {
 			}
 
 			// Re-render the preview when the attachment changes.
-			control.selectedAttachment = new wp.media.model.Attachment( { id: 0 } );
+			control.selectedAttachment = new wp.media.model.Attachment();
 			control.renderPreview = _.debounce( control.renderPreview );
 			control.listenTo( control.selectedAttachment, 'change', control.renderPreview );
 			control.listenTo( control.model, 'change', control.renderPreview );
 
 			// Make sure a copy of the selected attachment is always fetched.
-			control.model.on( 'change', control.fetchSelectedAttachment );
-			control.fetchSelectedAttachment();
+			control.model.on( 'change:attachment_id', control.updateSelectedAttachment );
+			control.model.on( 'change:url', control.updateSelectedAttachment );
+			control.updateSelectedAttachment();
 
 			/*
 			 * Sync the widget instance model attributes onto the hidden inputs that widgets currently use to store the state.
@@ -303,43 +304,27 @@ wp.mediaWidgets = ( function( $ ) {
 		},
 
 		/**
-		 * Fetch the selected attachment if necessary.
+		 * Update the selected attachment if necessary.
 		 *
 		 * @return {void}
 		 */
-		fetchSelectedAttachment: function fetchSelectedAttachment() {
+		updateSelectedAttachment: function updateSelectedAttachment() {
 			var control = this, attachment;
 
-			// This is an embed (by URL) image if the url is set and the attachment_id is 0.
-			if ( 0 === control.model.get( 'attachment_id' ) && control.model.get( 'url' ) ) {
-
-				// Construct an attachment model with the data we have.
-				attachment = new wp.media.model.Attachment( control.model.attributes );
-
-				control.selectedAttachment.set( _.extend( {}, attachment.attributes, { error: false } ) );
-
-				// Skip the rest.
-				return;
-			}
-
-			// Skip if selectedAttachment is already updated.
-			if ( control.model.get( 'attachment_id' ) === control.selectedAttachment.get( 'id' ) ) {
-				return;
-			}
-
-			control.selectedAttachment.clear( { silent: true } );
-			if ( ! control.model.get( 'attachment_id' ) ) {
-				control.selectedAttachment.set( { id: 0 } );
-			} else {
+			if ( 0 === control.model.get( 'attachment_id' ) ) {
+				control.selectedAttachment.clear();
+				control.model.set( 'error', false );
+			} else if ( control.model.get( 'attachment_id' ) !== control.selectedAttachment.get( 'id' ) ) {
 				attachment = new wp.media.model.Attachment( {
 					id: control.model.get( 'attachment_id' )
 				} );
 				attachment.fetch()
-					.done( function() {
-						control.selectedAttachment.set( _.extend( {}, attachment.attributes, { error: false } ) );
+					.done( function done() {
+						control.model.set( 'error', false );
+						control.selectedAttachment.set( attachment.toJSON() );
 					} )
-					.fail( function() {
-						control.selectedAttachment.set( { error: 'missing_attachment' } );
+					.fail( function fail() {
+						control.model.set( 'error', 'missing_attachment' );
 					} );
 			}
 		},
@@ -414,10 +399,14 @@ wp.mediaWidgets = ( function( $ ) {
 		/**
 		 * Whether a media item is selected.
 		 *
-		 * @return {boolean} Whether selected.
+		 * @return {boolean} Whether selected and no error.
 		 */
 		isSelected: function isSelected() {
 			var control = this;
+
+			if ( control.model.get( 'error' ) ) {
+				return false;
+			}
 
 			return Boolean( control.model.get( 'attachment_id' ) || control.model.get( 'url' ) );
 		},
@@ -456,7 +445,7 @@ wp.mediaWidgets = ( function( $ ) {
 
 			// Handle selection of a media item.
 			mediaFrame.on( 'insert', function onInsert() {
-				var attachment = { error: false }, state = mediaFrame.state();
+				var attachment = {}, state = mediaFrame.state();
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
 				if ( 'embed' === state.get( 'id' ) ) {
@@ -466,6 +455,7 @@ wp.mediaWidgets = ( function( $ ) {
 				}
 
 				control.selectedAttachment.set( attachment );
+				control.model.set( 'error', false );
 
 				// Update widget instance.
 				control.model.set( control.getSelectFrameProps( mediaFrame ) );

--- a/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/wp-includes/widgets/class-wp-widget-media-image.php
@@ -280,16 +280,16 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			<#
 			var describedById = 'describedBy-' + String( Math.random() );
 			#>
-			<# if ( data.attachment.error && 'missing_attachment' === data.attachment.error ) { #>
+			<# if ( data.error && 'missing_attachment' === data.error ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
-			<# } else if ( data.attachment.error ) { #>
+			<# } else if ( data.error ) { #>
 				<div class="notice notice-error notice-alt">
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
-			<# } else if ( data.attachment.url || data.url ) { #>
-				<img class="attachment-thumb" src="{{ data.attachment.url || data.url }}" draggable="false" alt="{{ data.alt }}" <# if ( ! data.alt ) { #> aria-describedby="{{ describedById }}" <# } #> />
+			<# } else if ( data.attachment_id || data.url ) { #>
+				<img class="attachment-thumb" src="{{ data.attachment_id && data.attachment.url ? data.attachment.url : data.url }}" draggable="false" alt="{{ data.alt }}" <# if ( ! data.alt ) { #> aria-describedby="{{ describedById }}" <# } #> />
 				<# if ( ! data.alt ) { #>
 					<#
 					var alt = ( data.attachment.url || data.url );


### PR DESCRIPTION
Moves `error` property from `selectedAttachment` model onto `control.model`, as suggested by @obenland.

Fixes #66.