### PR TITLE
Hide selection pane when no attachment isSelected()

### DIFF
--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -431,7 +431,7 @@ wp.mediaWidgets = ( function( $ ) {
 		selectMedia: function selectMedia() {
 			var control = this, selection, mediaFrame, defaultSync;
 
-			selection = new wp.media.model.Selection( [ control.selectedAttachment ] );
+			selection = control.isSelected() ? new wp.media.model.Selection( [ control.selectedAttachment ] ) : null;
 
 			mediaFrame = new component.MediaFrameSelect( {
 				title: control.l10n.select_media,
@@ -474,14 +474,16 @@ wp.mediaWidgets = ( function( $ ) {
 			mediaFrame.open();
 
 			// Clear the selected attachment when it is deleted in the media select frame.
-			selection.on( 'destroy', function onDestroy( attachment ) {
-				if ( control.model.get( 'attachment_id' ) === attachment.get( 'id' ) ) {
-					control.model.set( {
-						attachment_id: 0,
-						url: ''
-					} );
-				}
-			} );
+			if ( selection ) {
+				selection.on( 'destroy', function onDestroy( attachment ) {
+					if ( control.model.get( 'attachment_id' ) === attachment.get( 'id' ) ) {
+						control.model.set( {
+							attachment_id: 0,
+							url: ''
+						} );
+					}
+				} );
+			}
 
 			/*
 			 * Make sure focus is set inside of modal so that hitting Esc will close

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -431,7 +431,11 @@ wp.mediaWidgets = ( function( $ ) {
 		selectMedia: function selectMedia() {
 			var control = this, selection, mediaFrame, defaultSync;
 
-			selection = control.isSelected() ? new wp.media.model.Selection( [ control.selectedAttachment ] ) : null;
+			if ( control.isSelected() && 0 !== control.model.get( 'attachment_id' ) ) {
+				selection = new wp.media.model.Selection( [ control.selectedAttachment ] );
+			} else {
+				selection = null;
+			}
 
 			mediaFrame = new component.MediaFrameSelect( {
 				title: control.l10n.select_media,


### PR DESCRIPTION
Fixes #75.  In my testing, this approach seems to work well - but due to not fully groking all things `wp.media` yet, not certain if there are side-effects it could cause.

__Before__
Nexus5 Viewport:

<img width="408" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/24972297/d30732a8-1f6f-11e7-8a99-14618fff24fa.png">

Note when an empty `selection` is passed, the Add to Widget button is enabled here:

<img width="1215" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/24972319/e7fb3664-1f6f-11e7-8c9f-cca6c2794b13.png">


__After__
This looks much nicer on smaller viewports:

<img width="412" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/24972242/93a89a98-1f6f-11e7-96f3-bab35c4e6b47.png">

And large viewport, looks just like the add media dialog when first opened in the editor now, and the Add to Widget button is disabled since no media item is selected yet:

<img width="1217" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/24972260/acdc13aa-1f6f-11e7-9681-7e74bd11ea36.png">

