### PR TITLE
Remove flex layout on buttons

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -14,7 +14,7 @@
 }
 
 .media-widget-buttons .button {
-	margin: 10px 0 0 10px;
+	margin: 8px 0 0 8px;
 	width: auto;
 }
 .media-widget-control:not(.selected) .media-widget-buttons .button,

--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -9,7 +9,7 @@
 }
 
 .media-widget-buttons {
-	text-align: right;
+	text-align: left;
 	margin-bottom: 10px;
 }
 

--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -9,23 +9,13 @@
 }
 
 .media-widget-buttons {
-	display: -webkit-box;
-	display: -moz-box;
-	display: -ms-flexbox;
-	display: -webkit-flex;
-	display: flex;
+	text-align: right;
+	margin-bottom: 10px;
 }
 
 .media-widget-buttons .button {
-	-webkit-box-flex: 1;
-	-webkit-flex-grow: 1;
-	-moz-box-flex: 1;
-	-ms-flex-positive: 1;
-	-ms-flex: 1;
-	flex-grow: 1;
-}
-.media-widget-buttons .button {
-	margin-left: 10px;
+	margin: 10px 0 0 10px;
+	width: auto;
 }
 .media-widget-control:not(.selected) .media-widget-buttons .button,
 .media-widget-buttons .button:first-child {

--- a/wp-includes/widgets/class-wp-widget-media.php
+++ b/wp-includes/widgets/class-wp-widget-media.php
@@ -353,7 +353,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 					<p class="placeholder"><?php echo esc_html( $this->l10n['no_media_selected'] ); ?></p>
 				</div>
 			</div>
-			<p class="media-widget-buttons">
+			<div class="media-widget-buttons">
 				<button type="button" class="button edit-media selected">
 					<?php echo esc_html( $this->l10n['edit_media'] ); ?>
 				</button>
@@ -363,7 +363,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 				<button type="button" class="button select-media not-selected">
 					<?php echo esc_html( $this->l10n['select_media'] ); ?>
 				</button>
-			</p>
+			</div>
 		</script>
 		<?php
 	}


### PR DESCRIPTION
This branch fixes #49, and aligns with the proposed natural-width buttons in core ( https://core.trac.wordpress.org/ticket/40220 )

__Before__
![before](https://cloud.githubusercontent.com/assets/22080/25029270/9a0eab78-2070-11e7-9bfc-fdd70195b6ae.png)

__After__
![after](https://cloud.githubusercontent.com/assets/22080/25029271/9f89cbaa-2070-11e7-87a7-6a41999a8ce0.png)

__Long Strings__
![long-string](https://cloud.githubusercontent.com/assets/22080/25029277/a6b3c6f6-2070-11e7-920d-d7427b7f1034.png)
