### PR TITLE
Flesh out eslint and jscs rules for jsdoc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -141,13 +141,39 @@
 		"prefer-template": [0],
 		"quotes": [0],
 		"radix": [2, "always"],
+		"require-jsdoc": [2, {
+			"require": {
+				"FunctionDeclaration": true,
+				"MethodDefinition": true,
+				"ClassDeclaration": true,
+				"ArrowFunctionExpression": false
+			}
+		} ],
 		"require-yield": [0],
 		"sort-imports": [0],
 		"sort-vars": [0],
 		"strict": [2, "function"],
 		"use-isnan": [2],
 		"valid-typeof": [2],
-		"valid-jsdoc": [2],
+		"valid-jsdoc": [2, {
+			"prefer": {
+				"arg": "param",
+				"argument": "param",
+				"class": "constructor",
+				"return": "returns",
+				"virtual": "abstract"
+			},
+			"requireParamDescription": true,
+			"requireReturnDescription": true,
+			"requireReturn": true,
+			"requireReturnType": true,
+			"preferType": {
+				"Boolean": "boolean",
+				"Number": "number",
+				"object": "Object",
+				"String": "string"
+			}
+		}],
 		"vars-on-top": [0],
 		"wrap-iife": [2, "inside"],
 		"wrap-regex": [0],

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,1 +1,24 @@
-dev-lib/.jscsrc
+{
+	"preset": "wordpress",
+	"jsDoc": {
+		"checkAnnotations": "jsdoc3",
+		"checkParamExistence": true,
+		"checkParamNames": true,
+		"requireParamTypes": true,
+		"checkRedundantParams": true,
+		"checkReturnTypes": true,
+		"requireReturnTypes": true,
+		"checkTypes": "strictNativeCase",
+		"checkRedundantAccess": "enforceLeadingUnderscore",
+		"leadingUnderscoreAccess": "private",
+		"requireHyphenBeforeDescription": true,
+		"requireNewlineAfterDescription": true,
+		"requireParamDescription": true
+	},
+	"excludeFiles": [
+		"**/*.min.js",
+		"**/*.jsx",
+		"**/node_modules/**",
+		"**/vendor/**"
+	]
+}

--- a/wp-admin/js/widgets/media-image-widget.js
+++ b/wp-admin/js/widgets/media-image-widget.js
@@ -43,7 +43,7 @@
 		 * Get the instance props from the media selection frame.
 		 *
 		 * @param {wp.media.view.MediaFrame.Select} mediaFrame - Select frame.
-		 * @returns {object} Props from select frame.
+		 * @returns {Object} Props from select frame.
 		 */
 		getSelectFrameProps: function getSelectFrameProps( mediaFrame ) {
 			var control = this,
@@ -62,9 +62,10 @@
 		/**
 		 * Get the instance props from the media selection frame.
 		 *
+		 * @access private
 		 * @param {wp.media.view.MediaFrame.Select} mediaFrame - Select frame.
-		 * @param {object}                          attachment - Attachment object.
-		 * @returns {object} Attachment props.
+		 * @param {Object}                          attachment - Attachment object.
+		 * @returns {Object} Attachment props.
 		 */
 		_getAttachmentProps: function _getAttachmentProps( mediaFrame, attachment ) {
 			var props = {}, displaySettings;
@@ -96,9 +97,10 @@
 		/**
 		 * Get the instance props from the media selection frame.
 		 *
+		 * @access private
 		 * @param {wp.media.view.MediaFrame.Select} mediaFrame - Select frame.
-		 * @param {object}                          attachment - Attachment object.
-		 * @returns {object} Embed props.
+		 * @param {Object}                          attachment - Attachment object.
+		 * @returns {Object} Embed props.
 		 */
 		_getEmbedProps: function _getEmbedProps( mediaFrame, attachment ) {
 			var props = {};

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -33,7 +33,7 @@ wp.mediaWidgets = ( function( $ ) {
 		/**
 		 * Initialize.
 		 *
-		 * @param {object} options - Options.
+		 * @param {Object} options - Options.
 		 * @returns {void}
 		 */
 		initialize: function initialize( options ) {
@@ -42,7 +42,7 @@ wp.mediaWidgets = ( function( $ ) {
 		},
 
 		/**
-		 * Sync changes to the current display settings back into the current customized
+		 * Sync changes to the current display settings back into the current customized.
 		 *
 		 * @param {Backbone.Model} displaySettings - Modified display settings.
 		 * @returns {void}


### PR DESCRIPTION
I wanted to also add the `requireDescriptionCompleteSentence` and `enforceExistence` rules for JSCS, but they caused more problems than they solved.

It also seems like the `require-jsdoc` ESLint rule isn't applying to our class methods.

See #80.