### PR TITLE
Re-use oEmbed response to obtain thumbnail_id and set as poster image

### DIFF
--- a/wp-admin/js/widgets/media-video-widget.js
+++ b/wp-admin/js/widgets/media-video-widget.js
@@ -1,5 +1,5 @@
 /* eslint consistent-this: [ "error", "control" ] */
-(function( component, $ ) {
+(function( component ) {
 	'use strict';
 
 	var VideoWidgetModel, VideoWidgetControl;
@@ -50,7 +50,7 @@
 		 * @returns {void}
 		 */
 		renderPreview: function renderPreview() {
-			var control = this, previewContainer, model, previewTemplate, attachmentId, attachmentUrl;
+			var control = this, previewContainer, previewTemplate, attachmentId, attachmentUrl;
 			attachmentId = control.model.get( 'attachment_id' );
 			attachmentUrl = control.model.get( 'url' );
 
@@ -61,71 +61,14 @@
 			previewContainer = control.$el.find( '.media-widget-preview' );
 			previewTemplate = wp.template( 'wp-media-widget-video-preview' );
 
-			// If no attachment get the external thumbnail.
-			model = {
-				attachment_id: control.model.get( 'attachment_id' ),
-				src: attachmentUrl,
-				poster: control.model.get( 'poster' )
-			};
-			if ( ! attachmentId && ! control.model.get( 'poster' ) ) {
-				control.getExternalThumbnail().done( function( response ) {
-					model.poster = response.thumbnail_url;
-					previewContainer.html( previewTemplate( {
-						model: model,
-						error: control.model.get( 'error' )
-					} ) );
-				} );
-			} else {
-				previewContainer.html( previewTemplate( {
-					model: model,
-					error: control.model.get( 'error' )
-				} ) );
-			}
-
-		},
-
-		/**
-		 * Get the external video thumbnail for the preview
-		 *
-		 * @returns {Promise} Promise that resolves with oEmbed object containing thumbnail_url.
-		 */
-		getExternalThumbnail: function getExternalThumbnail() {
-			var control = this, urlParser = document.createElement( 'a' );
-			urlParser.href = control.model.get( 'url' ); // @todo Or mp4, ogv, webm, etc?
-
-			// YouTube does not support CORS, but the thumbnail URL can be constructed from the video ID.
-			if ( /youtube|youtu\.be/.test( urlParser.hostname ) ) {
-				return $.Deferred().resolveWith( control, [ {
-					thumbnail_url: 'https://img.youtube.com/vi/' + control._getYouTubeIdFromUrl( control.model.get( 'url' ) ) + '/mqdefault.jpg'
-				} ] ).promise();
-			}
-
-			// Else request Vimeo oEmbed data.
-			if ( /vimeo/.test( urlParser.hostname ) ) {
-				return $.ajax( {
-					url: 'https://vimeo.com/api/oembed.json?url=' + encodeURIComponent( control.model.get( 'url' ) ),
-					type: 'GET',
-					crossDomain: true,
-					dataType: 'json'
-				} );
-			}
-
-			// If the external video is hosted elsewhere, return default icon.
-			// TODO: Get markup/image for generic thumbnail
-			return $.Deferred().resolveWith( control, [ { thumbnail_url: '' } ] ).promise();
-		},
-
-		/**
-		 * Get YouTube video ID from URL.
-		 *
-		 * @access private
-		 * @param {string} url - URL from model.
-		 * @returns {string} YouTube video ID
-		 */
-		_getYouTubeIdFromUrl: function _getYouTubeIdFromUrl( url ) {
-			var urlParts;
-			urlParts = url.split( /(vi\/|v=|\/v\/|youtu\.be\/|\/embed\/)/ );
-			return ! _.isUndefined( urlParts[2] ) ? urlParts[2].split( /[^0-9a-z_\-]/i )[0] : urlParts[0];
+			previewContainer.html( previewTemplate( {
+				model: {
+					attachment_id: control.model.get( 'attachment_id' ),
+					src: attachmentUrl,
+					poster: control.model.get( 'poster' )
+				},
+				error: control.model.get( 'error' )
+			} ) );
 		},
 
 		/**
@@ -173,4 +116,4 @@
 	component.controlConstructors.media_video = VideoWidgetControl;
 	component.modelConstructors.media_video = VideoWidgetModel;
 
-})( wp.mediaWidgets, jQuery );
+})( wp.mediaWidgets );


### PR DESCRIPTION
Here's an experiment to piggyback on the existing oEmbed request that we're making to obtain the preview to then also populate the `poster`.

Amends #53.