### PR TITLE
Add background-color for videos

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -44,6 +44,9 @@
 .media-widget-control .media-widget-preview img {
 	max-width: 100%;
 }
+.media-widget-control .media-widget-preview .wp-video-shortcode {
+	background: #000;
+}
 .media-frame.media-widget .image-details .embed-media-settings .setting.align,
 .media-frame.media-widget .attachment-display-settings .setting.align,
 .media-frame.media-widget .embed-media-settings .setting.align,


### PR DESCRIPTION
Avoids showing a big space of nothing in browsers like Safari.

See https://github.com/xwp/wp-core-media-widgets/issues/36#issuecomment-296772238

Before:
![screen shot 2017-04-24 at 10 59 51 am](https://cloud.githubusercontent.com/assets/1398304/25351328/31918d3e-28dd-11e7-8974-521d91cb0d57.png)

After:
<img width="295" alt="screen shot 2017-04-26 at 8 56 35 am" src="https://cloud.githubusercontent.com/assets/1398304/25443957/553f230e-2a5e-11e7-8d55-3ca7235ac90f.png">
<img width="282" alt="screen shot 2017-04-26 at 8 56 55 am" src="https://cloud.githubusercontent.com/assets/1398304/25443970/5ba24b54-2a5e-11e7-914e-cf05fe1934d7.png">
