### PR TITLE
Maintain button margin on small screens

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -13,7 +13,7 @@
 	margin-bottom: 10px;
 }
 
-.media-widget-buttons .button {
+.media-widget-control .media-widget-buttons .button {
 	margin: 8px 0 0 8px;
 	width: auto;
 }


### PR DESCRIPTION
There is a default mobile style for customizer buttons that is more specific than our selector was.

See https://github.com/xwp/wp-core-media-widgets/issues/36#issuecomment-296788423

Before:
![screen shot 2017-04-24 at 11 49 21 am](https://cloud.githubusercontent.com/assets/1398304/25353459/1d4a0822-28e4-11e7-8857-65ad4cc0362c.png)

After:
<img width="369" alt="screen shot 2017-04-26 at 9 04 20 am" src="https://cloud.githubusercontent.com/assets/1398304/25444344/9de620de-2a5f-11e7-9f77-f512c00c23da.png">
