### PR TITLE
Don't pass a selection or metadata on selectMedia

### DIFF
--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -572,29 +572,22 @@ wp.mediaWidgets = ( function( $ ) {
 		 * @returns {void}
 		 */
 		selectMedia: function selectMedia() {
-			var control = this, selection, mediaFrame, defaultSync, mediaFrameProps;
+			var control = this, selection, mediaFrame, defaultSync;
 
 			if ( control.isSelected() && 0 !== control.model.get( 'attachment_id' ) ) {
 				selection = new wp.media.model.Selection( [ control.selectedAttachment ] );
-			} else {
-				selection = null;
-			}
-
-			mediaFrameProps = control.mapModelToMediaFrameProps( control.model.toJSON() );
-			if ( mediaFrameProps.size ) {
-				control.displaySettings.set( 'size', mediaFrameProps.size );
 			}
 
 			mediaFrame = new component.MediaFrameSelect({
 				title: control.l10n.select_media,
 				frame: 'post',
 				text: control.l10n.add_to_widget,
-				selection: selection,
+				selection: null,
 				mimeType: control.mime_type,
 				selectedDisplaySettings: control.displaySettings,
 				showDisplaySettings: control.showDisplaySettings,
-				metadata: mediaFrameProps,
-				state: control.isSelected() && 0 === control.model.get( 'attachment_id' ) ? 'embed' : 'insert'
+				metadata: {},
+				state: 'insert'
 			});
 			wp.media.frame = mediaFrame; // See wp.media().
 
@@ -603,11 +596,7 @@ wp.mediaWidgets = ( function( $ ) {
 				var attachment = {}, state = mediaFrame.state();
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				if ( 'embed' === state.get( 'id' ) ) {
-					_.extend( attachment, { id: 0 }, state.props.toJSON() );
-				} else {
-					_.extend( attachment, state.get( 'selection' ).first().toJSON() );
-				}
+				_.extend( attachment, state.get( 'selection' ).first().toJSON() );
 
 				control.selectedAttachment.set( attachment );
 				control.model.set( 'error', false );

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -596,7 +596,11 @@ wp.mediaWidgets = ( function( $ ) {
 				var attachment = {}, state = mediaFrame.state();
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				_.extend( attachment, state.get( 'selection' ).first().toJSON() );
+				if ( 'embed' === state.get( 'id' ) ) {
+					_.extend( attachment, { id: 0 }, state.props.toJSON() );
+				} else {
+					_.extend( attachment, state.get( 'selection' ).first().toJSON() );
+				}
 
 				control.selectedAttachment.set( attachment );
 				control.model.set( 'error', false );


### PR DESCRIPTION
Fixes #103 - This proposed change is to always have the `selectMedia()` method open the media modal in `select` state, regardless of if a media item is currently set in the widget.  To me the intention of clicking "Change Media" in the widget is to do just that - select an entirely new media item.  Currently when clicking "Change Media" the existing media item details are populated in the modal which I feel users could find confusing.

Curious for your thoughts on this idea @westonruter - or if there is another reason for keeping the `embed` state active when clicking "Change Media"