### PR TITLE
Populate link_url for non-custom linkTo settings

### DIFF
--- a/tests/qunit/test-media-image-widget.js
+++ b/tests/qunit/test-media-image-widget.js
@@ -59,6 +59,12 @@
 		imageWidgetControlInstance.$el.find( '.title' ).val( 'Chicken and Ribs' ).trigger( 'input' );
 		equal( imageWidgetModelInstance.get( 'title' ), 'Chicken and Ribs', 'Changing title should update model title attribute' );
 
+		// Test mapMediaToModelProps
+		mappedProps = imageWidgetControlInstance.mapMediaToModelProps( { link: 'file', url: testImageUrl } );
+		equal( mappedProps.link_url, testImageUrl, 'mapMediaToModelProps should set file link_url according to mediaFrameProps.link' );
+		mappedProps = imageWidgetControlInstance.mapMediaToModelProps( { link: 'custom', linkUrl: 'https://wordpress.org' } );
+		equal( mappedProps.link_url, 'https://wordpress.org', 'mapMediaToModelProps should set custom link_url according to mediaFrameProps.linkUrl' );
+
 		// Test mapModelToMediaFrameProps().
 		imageWidgetControlInstance.model.set({ error: false, url: testImageUrl, 'link_type': 'custom', 'link_url': 'https://wordpress.org', 'size': 'custom', 'width': 100, 'height': 150, 'title': 'widget title', 'image_title': 'title of image' });
 		mappedProps = imageWidgetControlInstance.mapModelToMediaFrameProps( imageWidgetControlInstance.model.toJSON() );

--- a/tests/qunit/test-media-image-widget.js
+++ b/tests/qunit/test-media-image-widget.js
@@ -62,6 +62,8 @@
 		// Test mapMediaToModelProps
 		mappedProps = imageWidgetControlInstance.mapMediaToModelProps( { link: 'file', url: testImageUrl } );
 		equal( mappedProps.link_url, testImageUrl, 'mapMediaToModelProps should set file link_url according to mediaFrameProps.link' );
+		mappedProps = imageWidgetControlInstance.mapMediaToModelProps( { link: 'post', postUrl: 'https://wordpress.org/image-2/' } );
+		equal( mappedProps.link_url, 'https://wordpress.org/image-2/', 'mapMediaToModelProps should set file link_url according to mediaFrameProps.link' );
 		mappedProps = imageWidgetControlInstance.mapMediaToModelProps( { link: 'custom', linkUrl: 'https://wordpress.org' } );
 		equal( mappedProps.link_url, 'https://wordpress.org', 'mapMediaToModelProps should set custom link_url according to mediaFrameProps.linkUrl' );
 

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -726,6 +726,12 @@ wp.mediaWidgets = ( function( $ ) {
 				modelProps.height = mediaFrameProps.customHeight;
 			}
 
+			if ( 'post' === mediaFrameProps.link ) {
+				modelProps.link_url = control.selectedAttachment.get( 'link' );
+			} else if ( 'file' === mediaFrameProps.link ) {
+				modelProps.link_url = mediaFrameProps.url;
+			}
+
 			// Because some media frames use `id` instead of `attachment_id`.
 			if ( ! mediaFrameProps.attachment_id && mediaFrameProps.id ) {
 				modelProps.attachment_id = mediaFrameProps.id;

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -671,6 +671,8 @@ wp.mediaWidgets = ( function( $ ) {
 			state = mediaFrame.state();
 			if ( 'insert' === state.get( 'id' ) ) {
 				mediaFrameProps = state.get( 'selection' ).first().toJSON();
+				mediaFrameProps.postUrl = mediaFrameProps.link;
+
 				if ( control.showDisplaySettings ) {
 					_.extend(
 						mediaFrameProps,
@@ -727,7 +729,7 @@ wp.mediaWidgets = ( function( $ ) {
 			}
 
 			if ( 'post' === mediaFrameProps.link ) {
-				modelProps.link_url = control.selectedAttachment.get( 'link' );
+				modelProps.link_url = mediaFrameProps.postUrl;
 			} else if ( 'file' === mediaFrameProps.link ) {
 				modelProps.link_url = mediaFrameProps.url;
 			}


### PR DESCRIPTION
This will properly populate the "Link To" setting in the image widget's edit modal.

The amount of code and its complexity is a poor representation of the time and effort that went into figuring out how to fix this bug. Thanks @westonruter for the guidance.

Fixes #111