### PR TITLE
Prevent Widget Title Loss

### DIFF
--- a/tests/qunit/test-media-video-widget.js
+++ b/tests/qunit/test-media-video-widget.js
@@ -25,6 +25,12 @@
 		equal( mappedProps.url, testVideoUrl, 'mapModelToMediaFrameProps should set url' );
 		equal( mappedProps.loop, false, 'mapModelToMediaFrameProps should set loop' );
 		equal( mappedProps.preload, 'meta', 'mapModelToMediaFrameProps should set preload' );
+
+		// Test mapMediaToModelProps().
+		mappedProps = videoWidgetControlInstance.mapMediaToModelProps( { loop: false, preload: 'meta', url: testVideoUrl, title: 'random movie file title' } );
+		equal( mappedProps.title, undefined, 'mapMediaToModelProps should ignore title inputs' );
+		equal( mappedProps.loop, false, 'mapMediaToModelProps should set loop' );
+		equal( mappedProps.preload, 'meta', 'mapMediaToModelProps should set preload' );
 	});
 
 	asyncTest( 'video widget control renderPreview', function() {

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -739,7 +739,8 @@ wp.mediaWidgets = ( function( $ ) {
 				modelProps.attachment_id = mediaFrameProps.id;
 			}
 
-			return modelProps;
+			// Always omit the titles derived from mediaFrameProps.
+			return _.omit( modelProps, 'title' );
 		},
 
 		/**


### PR DESCRIPTION
Quite similar to #89 - I encountered another issue where the video widget title was being over-written by attachment titles.

__Steps To Recreate Bug on master__
- Add a new video widget
- Change the title of the widget
- Select a movie file from the library
- Note the widget title is not the same as it was before

Repeat these same steps with this branch to ensure all is fixed.