### PR TITLE
Video Widget: Grab Thumbnail from noembed for preview

### DIFF
--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -213,6 +213,10 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				<div class="notice notice-error notice-alt">
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
+			<# } else if ( data.model && ! data.model.attachment_id && data.model.poster ) { #>
+				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
+					<img src="{{ data.model.poster }}" />
+				</a>
 			<# } else if ( data.model && ! data.model.attachment_id ) { #>
 				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
 					<span class="dashicons dashicons-format-video"></span>


### PR DESCRIPTION
This branch seeks to close #121 by adding support for fetching external video thumbnails via noembed.  Some flows to test:

- Ensure locally hosted video still shows a player view `renderPreview`
- Verify thumbnails are displayed properly for external `url`s from YouTube, Vimeo etc
- Try changing videos on the same widget.  Local video -> YouTube -> Vimeo

Fixes #121.