### PR TITLE
Use phar for PHPCS 2.8.1 since builds are breaking in PHPCS 3.0.0

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -1,3 +1,4 @@
 CHECK_SCOPE=changed-files
 PHPCS_RULESET_FILE=phpcs.xml.dist
 WPCS_BRANCH=develop
+PHPCS_PHAR_URL=https://github.com/squizlabs/PHP_CodeSniffer/blob/700168ede59d6a7d45fc4a2feefde1d156eb4573/phpcs.phar?raw=true


### PR DESCRIPTION
See https://github.com/xwp/wp-dev-lib/pull/234