### PR TITLE
Replace pixel width from video with 100% width

### DIFF
--- a/tests/phpunit/test-class-wp-widget-media-video.php
+++ b/tests/phpunit/test-class-wp-widget-media-video.php
@@ -186,12 +186,10 @@ class Test_WP_Widget_Media_Video extends WP_UnitTestCase {
 		// Check default outputs.
 		$this->assertContains( 'preload="metadata"', $output );
 		$this->assertContains( 'class="wp-video"', $output );
-		$this->assertContains( 'max-width:100%', $output );
+		$this->assertContains( 'width:100%', $output );
 		$this->assertNotContains( 'height=', $output );
-		$this->assertContains( 'small-video.m4v', $output );
-
-		// Auto parses dimensions.
-		$this->assertContains( 'width="640"', $output );
+		$this->assertNotContains( 'width="', $output );
+		$this->assertContains( 'small-video.m4v', $output );// Auto parses dimensions.
 
 		ob_start();
 		$widget->render_media( array(

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -146,7 +146,8 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 	 */
 	public function inject_video_max_width_style( $html ) {
 		$html = preg_replace( '/\sheight="\d+"/', '', $html );
-		$html = preg_replace( '/(?<=\sstyle=")/', 'max-width:100%; ', $html, 1 );
+		$html = preg_replace( '/\swidth="\d+"/', '', $html );
+		$html = preg_replace( '/(?<=width:)\s*\d+px(?=;?)/', '100%', $html );
 		return $html;
 	}
 


### PR DESCRIPTION
Fixes #93 

YouTube, Vimeo, and MP4 attachment:

<img width="318" alt="screen shot 2017-05-04 at 22 53 35" src="https://cloud.githubusercontent.com/assets/134745/25734975/b65dfdbc-311c-11e7-8f16-ec970c869c3d.png">

And with MediaElement.js disabled (where the YouTube and Vimeo videos don't render, expectedly, since no library is shimming them):

<img width="313" alt="screen shot 2017-05-04 at 22 54 17" src="https://cloud.githubusercontent.com/assets/134745/25734980/d00c33c8-311c-11e7-8cb6-61bd07a9b50c.png">

