### PR TITLE
Prevent Title Loss When Editing Video

### DIFF
--- a/wp-admin/js/widgets/media-video-widget.js
+++ b/wp-admin/js/widgets/media-video-widget.js
@@ -196,7 +196,7 @@
 				control.selectedAttachment.set( mediaFrameProps );
 
 				control.model.set( _.extend(
-					control.model.defaults(),
+					_.omit( control.model.defaults(), 'title' ),
 					control.mapMediaToModelProps( mediaFrameProps ),
 					{ error: false }
 				) );


### PR DESCRIPTION
While looking at #130 I noted another flow that was causing the title of the video widget to be lost:

__Steps to Recreate__
- Add a video widget, set a title
- Edit the video widget to adjust `loop` value for example
- Note the widget title has been reset to the default empty string

Checkout this branch and note the steps above do not cause the title of the video widget to be reset to the default value.