### PR TITLE
Whitelist should_preview_update for video/audio

### DIFF
--- a/wp-includes/widgets/class-wp-widget-media-audio.php
+++ b/wp-includes/widgets/class-wp-widget-media-audio.php
@@ -151,7 +151,7 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 
 		$exported_schema = array();
 		foreach ( $this->get_instance_schema() as $field => $field_schema ) {
-			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format', 'media_prop' ) );
+			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format', 'media_prop', 'should_preview_update' ) );
 		}
 		wp_add_inline_script(
 			$handle,

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -187,7 +187,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 
 		$exported_schema = array();
 		foreach ( $this->get_instance_schema() as $field => $field_schema ) {
-			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format', 'media_prop' ) );
+			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format', 'media_prop', 'should_preview_update' ) );
 		}
 		wp_add_inline_script(
 			$handle,


### PR DESCRIPTION
Prevents the preview from updating when certain props change.

__Steps to Recreate__
- Add a video widget.
- Start entering a title for the widget.
- Note the preview updating with every key stroke.

Checkout this branch and note the steps above do not cause the preview to be refreshed.