### PR TITLE
Fix Video Loop Issues

### DIFF
--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -115,7 +115,10 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		if ( $attachment ) {
 			$src = wp_get_attachment_url( $attachment->ID );
 		} else {
-			$src = $instance['url'];
+
+			// Manually add the loop query argument.
+			$loop = $instance['loop'] ? '1' : '0';
+			$src = add_query_arg( 'loop', $loop, $instance['url'] );
 		}
 
 		if ( empty( $src ) ) {

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -118,7 +118,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 
 			// Manually add the loop query argument.
 			$loop = $instance['loop'] ? '1' : '0';
-			$src = add_query_arg( 'loop', $loop, $instance['url'] );
+			$src = empty( $instance['url'] ) ? $instance['url'] : add_query_arg( 'loop', $loop, $instance['url'] );
 		}
 
 		if ( empty( $src ) ) {


### PR DESCRIPTION
This is still in progress as I still have yet to find a solution for the YouTube looping.  This branch seeks to fix #130 - though.  While testing out the original report, I noticed that the loop issue was only happening on YouTube embeds, and not on Vimeo embeds.  But even when `loop` was true for Vimeo embeds - they were not looping in the rendered widget.

A fix for the vimeo issue can be seen in dddaa88 ( which apparently has made CI unhappy ).  By adding the `loop` query arg on the Vimeo url, the underlying iframe from Vimeo loops when expected to.  YouTube also supports this query arg ( https://developers.google.com/youtube/player_parameters ), but it appears that mediaelement is mangling with the YouTube embed url... because even when the logic in this branch adds the `loop` query arg appropriately, the iframe src that is subsequently rendered in the widget no longer has the argument:

![customize__blog_ _wordpress_develop](https://cloud.githubusercontent.com/assets/22080/25755367/991e0c82-3177-11e7-9daa-95697456d616.png)

If I manually add the `loop` query arg back into the iframe URL seen above, the YouTube video no longer loops.