### PR TITLE
Restore editor to text mode after move

### DIFF
--- a/wp-admin/js/widgets/text-widgets.js
+++ b/wp-admin/js/widgets/text-widgets.js
@@ -1,4 +1,4 @@
-/* global tinymce, QTags */
+/* global tinymce, QTags, switchEditors */
 /* eslint consistent-this: [ "error", "control" ] */
 wp.textWidgets = ( function( $ ) {
 	'use strict';
@@ -45,7 +45,7 @@ wp.textWidgets = ( function( $ ) {
 		 * @returns {void}
 		 */
 		render: function render() {
-			var control = this, changeDebounceDelay = 1000, iframeKeepAliveInterval = 1000, id, textarea;
+			var control = this, changeDebounceDelay = 1000, iframeKeepAliveInterval = 1000, id, textarea, restoreTextMode = false;
 			textarea = control.$el.find( 'textarea:first' );
 			id = textarea.attr( 'id' );
 
@@ -59,6 +59,9 @@ wp.textWidgets = ( function( $ ) {
 
 				// Destroy any existing editor so that it can be re-initialized after a widget-updated event.
 				if ( tinymce.get( id ) ) {
+					if ( tinymce.get( id ).isHidden() ) {
+						restoreTextMode = true;
+					}
 					delete tinymce.editors[ id ];
 					tinymce.remove( '#' + id );
 				}
@@ -86,6 +89,11 @@ wp.textWidgets = ( function( $ ) {
 				editor = window.tinymce.get( id );
 				if ( editor.initialized ) {
 					watchForDestroyedBody( control.$el.find( 'iframe' )[0] );
+
+					// If a prior mce instance was replaced, and it was in text mode, toggle to text mode.
+					if ( restoreTextMode ) {
+						switchEditors.go( id, 'toggle' );
+					}
 				} else {
 					editor.on( 'init', function() {
 						watchForDestroyedBody( control.$el.find( 'iframe' )[0] );


### PR DESCRIPTION
This branch fixes #137.  The proposed solution here is to track wether or not the current mce instance `isHidden()` prior to being removed, and if it was `hidden`/ in text mode, utilize `switchEditors.go` to toggle the editor ( thanks for the tip @azaozz ! )

__To Test__
- Add a text widget
- Add some content, toggle to the Text tab
- Move the widget 
- Verify the freshly rendered MCE instance has the Text tab toggled on