### PR TITLE
Fix width of attachment filters container

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -47,6 +47,11 @@
 .media-widget-control .media-widget-preview .wp-video-shortcode {
 	background: #000;
 }
+
+.media-frame.media-widget .media-toolbar-secondary {
+	min-width: 300px;
+}
+
 .media-frame.media-widget .image-details .embed-media-settings .setting.align,
 .media-frame.media-widget .attachment-display-settings .setting.align,
 .media-frame.media-widget .embed-media-settings .setting.align,


### PR DESCRIPTION
Fixes #153 

For some reason the container is not wide enough when there is only one select drop-down filter to cause the right `calc()` computations, apparently.

Results:

![image](https://cloud.githubusercontent.com/assets/134745/25822609/f5a1c21e-33ed-11e7-9cd7-02bc4169cd5c.png)
