### PR TITLE
Make volume tooltip visible

### DIFF
--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -98,3 +98,8 @@
 .wp-customizer #wp-link-wrap {
 	z-index: 500105; /* originally 100105, but z-index of .wp-full-overlay is 500000 */
 }
+
+.wp-customizer .mejs-controls a:focus > .mejs-offscreen,
+.widgets-php .mejs-controls a:focus > .mejs-offscreen {
+	z-index: 2;
+}


### PR DESCRIPTION
This branch fixes #140 by adding a z-index value for the mejs volume slider in the context of the customizer and the widget admin.  The scrollbar and width of the customizer sidebar still cuts off the toolbar a bit:

<img width="325" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/25875159/da495224-34ca-11e7-9aa8-b49ea4ae433f.png">

Any styling/font changes on the tooltip itself should probably be handled in a core ticket.

Widget Admin:

<img width="369" alt="widgets_ _wordpress_develop_ _wordpress" src="https://cloud.githubusercontent.com/assets/22080/25875193/fc113fac-34ca-11e7-9a4b-62a989254b54.png">
