### PR TITLE
Remove workaround call to QTags._buttonsInit() due to core fixes

### DIFF
--- a/wp-admin/js/widgets/text-widgets.js
+++ b/wp-admin/js/widgets/text-widgets.js
@@ -1,4 +1,4 @@
-/* global tinymce, QTags, switchEditors */
+/* global tinymce, switchEditors */
 /* eslint consistent-this: [ "error", "control" ] */
 wp.textWidgets = ( function( $ ) {
 	'use strict';
@@ -131,7 +131,6 @@ wp.textWidgets = ( function( $ ) {
 					},
 					quicktags: true
 				} );
-				QTags._buttonsInit(); // @todo Remove once <https://core.trac.wordpress.org/ticket/35760#comment:28> is resolved.
 
 				editor = window.tinymce.get( id );
 				if ( ! editor ) {


### PR DESCRIPTION
See:
* https://wordpress.slack.com/archives/C0381N237/p1494384832790462
* https://core.trac.wordpress.org/ticket/26183
* https://core.trac.wordpress.org/ticket/40708