### PR TITLE
Ensure l10n exports clone before extending to prevent inadvertent overriding

### DIFF
--- a/wp-includes/widgets/class-wp-widget-media-audio.php
+++ b/wp-includes/widgets/class-wp-widget-media-audio.php
@@ -167,7 +167,7 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 			sprintf(
 				'
 					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.mime_type = %2$s;
-					_.extend( wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
+					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n = _.extend( {}, wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
 				',
 				wp_json_encode( $this->id_base ),
 				wp_json_encode( $this->widget_options['mime_type'] ),

--- a/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/wp-includes/widgets/class-wp-widget-media-image.php
@@ -280,7 +280,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			sprintf(
 				'
 					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.mime_type = %2$s;
-					_.extend( wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
+					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n = _.extend( {}, wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
 				',
 				wp_json_encode( $this->id_base ),
 				wp_json_encode( $this->widget_options['mime_type'] ),

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -206,7 +206,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			sprintf(
 				'
 					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.mime_type = %2$s;
-					_.extend( wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
+					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n = _.extend( {}, wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
 				',
 				wp_json_encode( $this->id_base ),
 				wp_json_encode( $this->widget_options['mime_type'] ),


### PR DESCRIPTION
Fixes issue raised by @celloexpressions in https://github.com/xwp/wordpress-develop/pull/227#issuecomment-299611866

> The audio widget seems to open a modal titled "select video" for me. Which is part of why I tried trowing a youtube URL into it.