### PR TITLE
Show error when unsupported video type is selected.

### DIFF
--- a/tests/phpunit/test-class-wp-widget-media-video.php
+++ b/tests/phpunit/test-class-wp-widget-media-video.php
@@ -54,6 +54,7 @@ class Test_WP_Widget_Media_Video extends WP_UnitTestCase {
 		$this->assertEqualSets( array(
 			'add_to_widget',
 			'replace_media',
+			'unsupported_file_type',
 			'edit_media',
 			'media_library_state_multi',
 			'media_library_state_single',

--- a/wp-admin/css/widgets/media-widgets.css
+++ b/wp-admin/css/widgets/media-widgets.css
@@ -41,6 +41,9 @@
 .media-widget-control .media-widget-preview .notice {
 	text-align: initial;
 }
+.media-widget-control .notice p {
+	padding: 0 3px 0 0;
+}
 .media-widget-control .media-widget-preview img {
 	max-width: 100%;
 }

--- a/wp-admin/js/widgets/media-video-widget.js
+++ b/wp-admin/js/widgets/media-video-widget.js
@@ -138,9 +138,10 @@
 		 * @returns {void}
 		 */
 		renderPreview: function renderPreview() {
-			var control = this, previewContainer, previewTemplate, attachmentId, attachmentUrl, poster, isHostedEmbed = false, parsedUrl;
+			var control = this, previewContainer, previewTemplate, attachmentId, attachmentUrl, poster, isHostedEmbed = false, parsedUrl, mime, error;
 			attachmentId = control.model.get( 'attachment_id' );
 			attachmentUrl = control.model.get( 'url' );
+			error = control.model.get( 'error' );
 
 			if ( ! attachmentId && ! attachmentUrl ) {
 				return;
@@ -157,6 +158,14 @@
 				poster = control.oembedResponses[ attachmentUrl ] ? control.oembedResponses[ attachmentUrl ].thumbnail_url : null;
 			}
 
+			// Verify the selected attachment mime is supported.
+			mime = control.selectedAttachment.get( 'mime' );
+			if ( mime && attachmentId ) {
+				if ( ! _.contains( _.values( wp.media.view.settings.embedMimes ), mime ) ) {
+					error = 'unsupported_file_type';
+				}
+			}
+
 			previewContainer = control.$el.find( '.media-widget-preview' );
 			previewTemplate = wp.template( 'wp-media-widget-video-preview' );
 
@@ -167,7 +176,7 @@
 					poster: poster
 				},
 				is_hosted_embed: isHostedEmbed,
-				error: control.model.get( 'error' )
+				error: error
 			} ) );
 		},
 

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -42,7 +42,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			'media_library_state_multi' => _n_noop( 'Video Widget (%d)', 'Video Widget (%d)' ),
 			'media_library_state_single' => __( 'Video Widget' ),
 			/* translators: placeholder is a list of valid video file extensions */
-			'unsupported_file_type' => sprintf( __( 'Sorry, we can\'t display the video file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
+			'unsupported_file_type' => sprintf( __( 'Sorry, we can&#8217;t display the video file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
 		) );
 	}
 

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -41,6 +41,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			/* translators: %d is widget count */
 			'media_library_state_multi' => _n_noop( 'Video Widget (%d)', 'Video Widget (%d)' ),
 			'media_library_state_single' => __( 'Video Widget' ),
+			/* translators: placeholder is a list of valid video file extensions */
 			'unsupported_file_type' => sprintf( __( 'Sorry, we can\'t display the movie file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
 		) );
 	}

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -42,7 +42,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			'media_library_state_multi' => _n_noop( 'Video Widget (%d)', 'Video Widget (%d)' ),
 			'media_library_state_single' => __( 'Video Widget' ),
 			/* translators: placeholder is a list of valid video file extensions */
-			'unsupported_file_type' => sprintf( __( 'Sorry, we can\'t display the movie file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
+			'unsupported_file_type' => sprintf( __( 'Sorry, we can\'t display the video file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
 		) );
 	}
 

--- a/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/wp-includes/widgets/class-wp-widget-media-video.php
@@ -41,6 +41,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			/* translators: %d is widget count */
 			'media_library_state_multi' => _n_noop( 'Video Widget (%d)', 'Video Widget (%d)' ),
 			'media_library_state_single' => __( 'Video Widget' ),
+			'unsupported_file_type' => sprintf( __( 'Sorry, we can\'t display the movie file type selected. Please upload a file with one of these extensions instead: %1$s' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
 		) );
 	}
 
@@ -228,6 +229,10 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			<# if ( data.error && 'missing_attachment' === data.error ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
+				</div>
+			<# } else if ( data.error && 'unsupported_file_type' === data.error ) { #>
+				<div class="notice notice-error notice-alt notice-missing-attachment">
+					<p><?php echo $this->l10n['unsupported_file_type']; ?></p>
 				</div>
 			<# } else if ( data.error ) { #>
 				<div class="notice notice-error notice-alt">


### PR DESCRIPTION
This branch seeks to inform users that certain video file types are not supported via the `renderPreview()` in the widget itself.  The `.mov` issue detailed in #171 is a bit complex - and until uploads can be properly restricted ( #128 ) - users will still be able to upload a .mov file which will not function properly when the widget is rendered on the front-end of the site.

So this branch is implementing @jasmussen 's [idea](https://github.com/xwp/wp-core-media-widgets/issues/171#issuecomment-300549660) - to not render a functioning `<video />` preview in the widget for a file type that we know will not work.  I borrowed @obenland's error message suggestion:

<img width="263" alt="customize__wordpress_develop_ _just_another_wordpress_site" src="https://cloud.githubusercontent.com/assets/22080/25920752/cdd0acc8-3587-11e7-8727-4cf879feda87.png">

__To Test__
- Create a video widget using a supported file type ( .webm, .m4v etc ) verify that the preview renders as expected
- Create a video widget using a .mov file, and verify the preview renders with an error message