### PR TITLE
Limit the MIME types to just those that are embeddable

### DIFF
--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -243,6 +243,16 @@ wp.mediaWidgets = ( function( $ ) {
 		 * @returns {void}
 		 */
 		createStates: function createStates() {
+			var mime = this.options.mimeType, specificMimes = [];
+			_.each( wp.media.view.settings.embedMimes, function( embedMime ) {
+				if ( 0 === embedMime.indexOf( mime ) ) {
+					specificMimes.push( embedMime );
+				}
+			});
+			if ( specificMimes.length > 0 ) {
+				mime = specificMimes.join( ',' );
+			}
+
 			this.states.add( [
 
 				// Main states.
@@ -254,7 +264,7 @@ wp.mediaWidgets = ( function( $ ) {
 					toolbar:    'main-insert',
 					filterable: 'dates',
 					library:    wp.media.query({
-						type: this.options.mimeType
+						type: mime
 					}),
 					multiple:   false,
 					editable:   true,


### PR DESCRIPTION
This prevents MOV files from appearing in the list files available to embed for the video widget. It won't currently prevent a MOV from being uploaded (#128) but it _does_ make it so that once you've uploaded a MOV it won't appear in the list, even though it _will_ be selected and appear in the attachment details with the Add to Widget button being enabled.

See #171.