### PR TITLE
Use new oembed/proxy endpoint instead of noembed

### DIFF
--- a/wp-admin/js/widgets/media-video-widget.js
+++ b/wp-admin/js/widgets/media-video-widget.js
@@ -111,15 +111,16 @@
 			}
 
 			control.fetchEmbedDfd = jQuery.ajax({
-				url: 'https://noembed.com/embed',
+				url: wp.media.view.settings.oEmbedProxyUrl,
 				data: {
 					url: control.model.get( 'url' ),
 					maxwidth: control.model.get( 'width' ),
-					maxheight: control.model.get( 'height' )
+					maxheight: control.model.get( 'height' ),
+					_wpnonce: wp.media.view.settings.nonce.wpRestApi
 				},
 				type: 'GET',
-				crossDomain: true,
-				dataType: 'json'
+				dataType: 'json',
+				context: control
 			});
 
 			control.fetchEmbedDfd.done( function( response ) {

--- a/wp-admin/js/widgets/media-video-widget.js
+++ b/wp-admin/js/widgets/media-video-widget.js
@@ -116,7 +116,8 @@
 					url: control.model.get( 'url' ),
 					maxwidth: control.model.get( 'width' ),
 					maxheight: control.model.get( 'height' ),
-					_wpnonce: wp.media.view.settings.nonce.wpRestApi
+					_wpnonce: wp.media.view.settings.nonce.wpRestApi,
+					discover: false
 				},
 				type: 'GET',
 				dataType: 'json',

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -187,7 +187,8 @@ wp.mediaWidgets = ( function( $ ) {
 								url: embedLinkView.model.get( 'url' ),
 								maxwidth: embedLinkView.model.get( 'width' ),
 								maxheight: embedLinkView.model.get( 'height' ),
-								_wpnonce: wp.media.view.settings.nonce.wpRestApi
+								_wpnonce: wp.media.view.settings.nonce.wpRestApi,
+								discover: false
 							},
 							type: 'GET',
 							dataType: 'json',

--- a/wp-admin/js/widgets/media-widgets.js
+++ b/wp-admin/js/widgets/media-widgets.js
@@ -182,15 +182,16 @@ wp.mediaWidgets = ( function( $ ) {
 						}
 
 						embedLinkView.dfd = $.ajax({
-							url: 'https://noembed.com/embed', // @todo Replace with core proxy endpoint once committed.
+							url: wp.media.view.settings.oEmbedProxyUrl,
 							data: {
 								url: embedLinkView.model.get( 'url' ),
 								maxwidth: embedLinkView.model.get( 'width' ),
-								maxheight: embedLinkView.model.get( 'height' )
+								maxheight: embedLinkView.model.get( 'height' ),
+								_wpnonce: wp.media.view.settings.nonce.wpRestApi
 							},
 							type: 'GET',
-							crossDomain: true,
-							dataType: 'json'
+							dataType: 'json',
+							context: embedLinkView
 						});
 
 						embedLinkView.dfd.done( function( response ) {


### PR DESCRIPTION
This branch removes usage of noembed and implements the new `oembed/proxy` REST API endpoint instead.  Requires to have the branch https://github.com/xwp/wordpress-develop/pull/225 installed to test.