### PR TITLE
Skip adding visual text widget if already merged into core

### DIFF
--- a/core-media-widgets.php
+++ b/core-media-widgets.php
@@ -30,6 +30,8 @@ if ( defined( 'WP_CLI' ) ) {
 	WP_CLI::add_command( 'media-widgets', new Media_Widgets_WP_CLI_Command() );
 }
 
+define( 'WP_CORE_VISUAL_TEXT_WIDGET_MERGED', file_exists( ABSPATH . 'wp-admin/js/widgets/text-widgets.js' ) );
+
 /**
  * Register widget scripts.
  *
@@ -37,7 +39,7 @@ if ( defined( 'WP_CLI' ) ) {
  * @param WP_Scripts $scripts Scripts.
  */
 function wp32417_default_scripts( WP_Scripts $scripts ) {
-	if ( function_exists( 'wp_enqueue_editor' ) ) {
+	if ( function_exists( 'wp_enqueue_editor' ) && ! WP_CORE_VISUAL_TEXT_WIDGET_MERGED ) {
 		$scripts->add( 'text-widgets', plugin_dir_url( __FILE__ ) . 'wp-admin/js/widgets/text-widgets.js', array( 'jquery', 'backbone', 'editor', 'wp-util' ) );
 		$scripts->add_inline_script( 'text-widgets', 'wp.textWidgets.init();', 'after' );
 	}
@@ -62,7 +64,9 @@ function wp32417_add_default_filters() {
 	add_filter( 'widget_text_content', 'convert_smilies', 20 );
 	add_filter( 'widget_text_content', 'wpautop' );
 }
-add_action( 'plugins_loaded', 'wp32417_add_default_filters' );
+if ( ! WP_CORE_VISUAL_TEXT_WIDGET_MERGED ) {
+	add_action( 'plugins_loaded', 'wp32417_add_default_filters' );
+}
 
 /**
  * Register widget styles.
@@ -111,7 +115,7 @@ function wp32417_widgets_init() {
 	register_widget( 'WP_Widget_Media_Video' );
 	register_widget( 'WP_Widget_Media_Audio' );
 
-	if ( function_exists( 'wp_enqueue_editor' ) ) {
+	if ( function_exists( 'wp_enqueue_editor' ) && ! WP_CORE_VISUAL_TEXT_WIDGET_MERGED ) {
 		require_once( dirname( __FILE__ ) . '/wp-includes/widgets/class-wp-widget-visual-text.php' );
 		unregister_widget( 'WP_Widget_Text' );
 		register_widget( 'WP_Widget_Visual_Text' );


### PR DESCRIPTION
Useful for once https://github.com/xwp/wordpress-develop/pull/230 is committed to `trunk`.