### PR TITLE
Remove attachment data from gallery widget schema.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 notifications:
   email:

--- a/tests/phpunit/test-class-wp-widget-media-gallery.php
+++ b/tests/phpunit/test-class-wp-widget-media-gallery.php
@@ -30,7 +30,6 @@ class Test_WP_Widget_Media_Gallery extends WP_UnitTestCase {
 				'size',
 				'link_type',
 				'orderby_random',
-				'attachments',
 			),
 			array_keys( $schema )
 		);

--- a/wp-admin/js/widgets/media-gallery-widget.js
+++ b/wp-admin/js/widgets/media-gallery-widget.js
@@ -93,7 +93,7 @@
 			previewContainer = control.$el.find( '.media-widget-preview' );
 			previewTemplate = wp.template( 'wp-media-widget-gallery-preview' );
 
-			if ( control.model.get( 'ids').length && ! control.model.get( 'attachemnts' ) ) {
+			if ( control.model.get( 'ids' ).length && ! control.model.get( 'attachemnts' ) ) {
 				attachments = this.getAttachments();
 
 				attachments.more().done( function() {
@@ -120,7 +120,7 @@
 				perPage: -1,
 				post__in: ids,
 				query: true,
-				type: 'image',
+				type: 'image'
 			} );
 
 			return attachments;

--- a/wp-includes/widgets/class-wp-widget-media-gallery.php
+++ b/wp-includes/widgets/class-wp-widget-media-gallery.php
@@ -89,10 +89,6 @@ class WP_Widget_Media_Gallery extends WP_Widget_Media {
 				'media_prop'            => '_orderbyRandom',
 				'should_preview_update' => false,
 			),
-			'attachments' => array(
-				'type'                  => 'string',
-				'default' => '',
-			),
 		);
 	}
 


### PR DESCRIPTION
To avoid saving attachment data with the widget, this removes attachments
from the schema and makes use of the IDs we're saving to fetch attachment
data before the widget preview is renedered.